### PR TITLE
[Chore] Actuator 헬스체크 엔드포인트 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,10 @@ dependencies {
 
     // Swagger (SpringDoc OpenAPI)
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+
+    // Health Check
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
@@ -42,6 +46,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // Test DB
     runtimeOnly 'com.h2database:h2'
 }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,16 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.type.descriptor.sql.BasicBinder: TRACE
 
+management:
+  endpoints:
+    web:
+      base-path: /api      # 기본 /actuator를 /api로 변경
+      exposure:
+        include: health    # health 엔드포인트만 노출
+  endpoint:
+    health:
+      show-details: always # DB 상태 등을 포함한 상세 정보 출력
+
 # JWT (기본 구조만 공유)
 jwt:
   # 실제 배포 시에는 환경변수로 주입하거나 application-prod.yml에서 JWT 관련 설정을 따로 관리함


### PR DESCRIPTION
## 📝 작업 요약
- Spring Boot Actuator 의존성 추가 및 `/api/health` 헬스체크 엔드포인트 설정

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] `build.gradle`에 `spring-boot-starter-actuator` 의존성 추가
- [x] `application.yml`에 Actuator management 설정 추가 (`/api/health` 경로 노출)

## 🔍 리뷰 포인트
- **로직**: Actuator health 엔드포인트가 `/api/health` 경로로 정상 노출되는지 확인
- **보안**: `show-details: always` 설정이 개발 환경에서만 사용되는지 확인
- prod에서는 `never` 또는 `when-authorized` 권장하며, staging 및 local에서는 상세 정보 확인할 수 있게 하였음.
- 이에 겸해서 CD 재확인 겸 PR 열었습니다.

## 📸 테스트 결과 (선택 사항)
## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting (선택 사항)
- N/A