### PR TITLE
[Fix] Blue-Green 배포 시 Nginx 트래픽 전환 로직 강화

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -153,21 +153,55 @@ jobs:
               # ========================================
               echo "=== Step 6: Update Nginx Configuration ==="
 
-              # Host의 Nginx 설정 파일 수정
-              if [ -f "$NGINX_CONF" ]; then
-                sed -i "s/whoreads-prod-\(blue\|green\)/whoreads-prod-$NEW/g" "$NGINX_CONF"
-                echo "Updated nginx config to point to: whoreads-prod-$NEW"
-              else
-                echo "Warning: Nginx config not found at $NGINX_CONF"
+              # 6-1. Nginx 설정 파일 존재 확인 (필수)
+              if [ ! -f "$NGINX_CONF" ]; then
+                echo "ERROR: Nginx config not found at $NGINX_CONF"
+                echo "Please ensure Nginx is properly set up on the server."
+                docker stop "whoreads-prod-$NEW" 2>/dev/null || true
+                docker rm "whoreads-prod-$NEW" 2>/dev/null || true
+                exit 1
               fi
 
-              # Nginx 컨테이너 리로드
-              if docker ps --filter "name=$NGINX_CONTAINER" --format "{{.Names}}" | grep -q "$NGINX_CONTAINER"; then
-                docker exec "$NGINX_CONTAINER" nginx -s reload
-                echo "Nginx reloaded successfully"
+              # 6-2. 현재 설정 백업 및 변경
+              cp "$NGINX_CONF" "$NGINX_CONF.bak"
+              sed -i "s/whoreads-prod-\(blue\|green\)/whoreads-prod-$NEW/g" "$NGINX_CONF"
+
+              # 6-3. 변경 확인
+              if grep -q "whoreads-prod-$NEW" "$NGINX_CONF"; then
+                echo "Nginx config updated to point to: whoreads-prod-$NEW"
               else
-                echo "Warning: Nginx container '$NGINX_CONTAINER' not found or not running"
+                echo "ERROR: Failed to update Nginx config. Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-prod-$NEW" 2>/dev/null || true
+                docker rm "whoreads-prod-$NEW" 2>/dev/null || true
+                exit 1
               fi
+
+              # 6-4. Nginx 컨테이너 확인 (필수)
+              if ! docker ps --filter "name=$NGINX_CONTAINER" --format "{{.Names}}" | grep -q "$NGINX_CONTAINER"; then
+                echo "ERROR: Nginx container '$NGINX_CONTAINER' not found or not running"
+                echo "Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-prod-$NEW" 2>/dev/null || true
+                docker rm "whoreads-prod-$NEW" 2>/dev/null || true
+                exit 1
+              fi
+
+              # 6-5. Nginx 설정 검증
+              if ! docker exec "$NGINX_CONTAINER" nginx -t 2>&1; then
+                echo "ERROR: Nginx config validation failed. Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-prod-$NEW" 2>/dev/null || true
+                docker rm "whoreads-prod-$NEW" 2>/dev/null || true
+                exit 1
+              fi
+
+              # 6-6. Nginx 리로드
+              docker exec "$NGINX_CONTAINER" nginx -s reload
+              echo "Nginx reloaded successfully"
+
+              # 백업 파일 정리
+              rm -f "$NGINX_CONF.bak"
 
               # ========================================
               # 7. 이전 컨테이너 정리

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -153,21 +153,55 @@ jobs:
               # ========================================
               echo "=== Step 6: Update Nginx Configuration ==="
 
-              # Host의 Nginx 설정 파일 수정
-              if [ -f "$NGINX_CONF" ]; then
-                sed -i "s/whoreads-staging-\(blue\|green\)/whoreads-staging-$NEW/g" "$NGINX_CONF"
-                echo "Updated nginx config to point to: whoreads-staging-$NEW"
-              else
-                echo "Warning: Nginx config not found at $NGINX_CONF"
+              # 6-1. Nginx 설정 파일 존재 확인 (필수)
+              if [ ! -f "$NGINX_CONF" ]; then
+                echo "ERROR: Nginx config not found at $NGINX_CONF"
+                echo "Please ensure Nginx is properly set up on the server."
+                docker stop "whoreads-staging-$NEW" 2>/dev/null || true
+                docker rm "whoreads-staging-$NEW" 2>/dev/null || true
+                exit 1
               fi
 
-              # Nginx 컨테이너 리로드
-              if docker ps --filter "name=$NGINX_CONTAINER" --format "{{.Names}}" | grep -q "$NGINX_CONTAINER"; then
-                docker exec "$NGINX_CONTAINER" nginx -s reload
-                echo "Nginx reloaded successfully"
+              # 6-2. 현재 설정 백업 및 변경
+              cp "$NGINX_CONF" "$NGINX_CONF.bak"
+              sed -i "s/whoreads-staging-\(blue\|green\)/whoreads-staging-$NEW/g" "$NGINX_CONF"
+
+              # 6-3. 변경 확인
+              if grep -q "whoreads-staging-$NEW" "$NGINX_CONF"; then
+                echo "Nginx config updated to point to: whoreads-staging-$NEW"
               else
-                echo "Warning: Nginx container '$NGINX_CONTAINER' not found or not running"
+                echo "ERROR: Failed to update Nginx config. Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-staging-$NEW" 2>/dev/null || true
+                docker rm "whoreads-staging-$NEW" 2>/dev/null || true
+                exit 1
               fi
+
+              # 6-4. Nginx 컨테이너 확인 (필수)
+              if ! docker ps --filter "name=$NGINX_CONTAINER" --format "{{.Names}}" | grep -q "$NGINX_CONTAINER"; then
+                echo "ERROR: Nginx container '$NGINX_CONTAINER' not found or not running"
+                echo "Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-staging-$NEW" 2>/dev/null || true
+                docker rm "whoreads-staging-$NEW" 2>/dev/null || true
+                exit 1
+              fi
+
+              # 6-5. Nginx 설정 검증
+              if ! docker exec "$NGINX_CONTAINER" nginx -t 2>&1; then
+                echo "ERROR: Nginx config validation failed. Restoring backup..."
+                cp "$NGINX_CONF.bak" "$NGINX_CONF"
+                docker stop "whoreads-staging-$NEW" 2>/dev/null || true
+                docker rm "whoreads-staging-$NEW" 2>/dev/null || true
+                exit 1
+              fi
+
+              # 6-6. Nginx 리로드
+              docker exec "$NGINX_CONTAINER" nginx -s reload
+              echo "Nginx reloaded successfully"
+
+              # 백업 파일 정리
+              rm -f "$NGINX_CONF.bak"
 
               # ========================================
               # 7. 이전 컨테이너 정리


### PR DESCRIPTION
## 📝 작업 요약
- Blue-Green 배포 시 Nginx 트래픽 전환 로직 강화 및 에러 처리 추가

## 🔗 관련 이슈(있으면)
- #42

## 🛠 주요 변경 사항
- [x] Nginx 설정 파일 존재 여부 필수 확인 (없으면 배포 실패 처리)
- [x] sed 치환 전 백업, 치환 후 결과 검증
- [x] Nginx 컨테이너 실행 상태 필수 확인
- [x] `nginx -t`로 설정 문법 검증 후 reload
- [x] 모든 실패 케이스에서 백업 복원 및 새 컨테이너 롤백

## 🔍 리뷰 포인트
- **로직**: 실패 시 롤백 로직이 적절하게 구현되어 있나요?
- **성능**: N/A (인프라 스크립트)
- **보안**: N/A

## 📸 테스트 결과 (선택 사항)
- develop 브랜치 머지 후 staging 배포 테스트 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? (N/A)

## 🛠 Troubleshooting (선택 사항)
### 1. 문제 현상
- Blue-Green 배포 후 Nginx가 여전히 이전 컨테이너를 바라봐 502 Bad Gateway 발생

### 2. 원인 분석
- Nginx 설정 파일이 없거나 컨테이너가 없어도 Warning만 출력하고 배포가 "성공"으로 처리됨
- sed 치환 실패 시 감지 로직 없음

### 3. 해결 방안
- 모든 단계에서 필수 조건 검증 및 실패 시 즉시 exit 1
- 설정 변경 전 백업, 실패 시 복원
- nginx -t로 문법 검증 후 reload