### PR TITLE
[Fix] CI/CD 파이프라인 Firebase 설정 개선

### DIFF
--- a/.github/workflows/cd-prod.yml
+++ b/.github/workflows/cd-prod.yml
@@ -142,6 +142,9 @@ jobs:
             docker stop "whoreads-prod-$NEW" 2>/dev/null || true
             docker rm "whoreads-prod-$NEW" 2>/dev/null || true
 
+            # Firebase 시크릿 디코딩
+            FIREBASE_JSON=$(echo "${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}" | base64 -d)
+
             docker run -d \
               --name "whoreads-prod-$NEW" \
               --network "$NETWORK_NAME" \
@@ -153,6 +156,7 @@ jobs:
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
               -e ALADIN_KEY=${{ secrets.ALADIN_KEY }} \
               -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
+              -e FIREBASE_SECRET_JSON="$FIREBASE_JSON" \
               "$DOCKER_IMAGE"
 
             # ========================================

--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -142,6 +142,9 @@ jobs:
             docker stop "whoreads-staging-$NEW" 2>/dev/null || true
             docker rm "whoreads-staging-$NEW" 2>/dev/null || true
 
+            # Firebase 시크릿 디코딩
+            FIREBASE_JSON=$(echo "${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}" | base64 -d)
+
             docker run -d \
               --name "whoreads-staging-$NEW" \
               --network "$NETWORK_NAME" \
@@ -153,6 +156,7 @@ jobs:
               -e DB_PASSWORD=${{ secrets.DB_PASSWORD }} \
               -e ALADIN_KEY=${{ secrets.ALADIN_KEY }} \
               -e JWT_SECRET=${{ secrets.JWT_SECRET }} \
+              -e FIREBASE_SECRET_JSON="$FIREBASE_JSON" \
               "$DOCKER_IMAGE"
 
             # ========================================

--- a/src/main/java/whoreads/backend/global/config/FirebaseConfig.java
+++ b/src/main/java/whoreads/backend/global/config/FirebaseConfig.java
@@ -8,14 +8,19 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @Slf4j
 @Configuration
+@Profile("!test")
 public class FirebaseConfig {
     @Value("${firebase.secret.path}")
     private String serviceAccountPath;
@@ -23,10 +28,9 @@ public class FirebaseConfig {
     @Bean
     public FirebaseApp firebaseApp() {
         try {
+            InputStream credentialsStream = getCredentialsStream();
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(
-                            GoogleCredentials.fromStream(new ClassPathResource(serviceAccountPath).getInputStream())
-                    )
+                    .setCredentials(GoogleCredentials.fromStream(credentialsStream))
                     .build();
 
             return FirebaseApp.initializeApp(options);
@@ -34,6 +38,19 @@ public class FirebaseConfig {
         } catch (IOException exception) {
             throw new CustomException(ErrorCode.FCM_SERVER_UNAVAILABLE);
         }
+    }
+
+    private InputStream getCredentialsStream() throws IOException {
+        // 환경변수 우선 (배포 환경)
+        String firebaseJson = System.getenv("FIREBASE_SECRET_JSON");
+        if (firebaseJson != null && !firebaseJson.isEmpty()) {
+            log.info("Loading Firebase credentials from environment variable");
+            return new ByteArrayInputStream(firebaseJson.getBytes(StandardCharsets.UTF_8));
+        }
+
+        // 환경변수 없으면 파일에서 읽기 (로컬 환경)
+        log.info("Loading Firebase credentials from classpath: {}", serviceAccountPath);
+        return new ClassPathResource(serviceAccountPath).getInputStream();
     }
 
     @Bean

--- a/src/test/java/whoreads/backend/BackendApplicationTests.java
+++ b/src/test/java/whoreads/backend/BackendApplicationTests.java
@@ -2,8 +2,11 @@ package whoreads.backend;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import whoreads.backend.config.TestFirebaseConfig;
 
 @SpringBootTest
+@Import(TestFirebaseConfig.class)
 class BackendApplicationTests {
 
     @Test

--- a/src/test/java/whoreads/backend/config/TestFirebaseConfig.java
+++ b/src/test/java/whoreads/backend/config/TestFirebaseConfig.java
@@ -1,0 +1,24 @@
+package whoreads.backend.config;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+@TestConfiguration
+public class TestFirebaseConfig {
+
+    @Bean
+    @Primary
+    public FirebaseApp firebaseApp() {
+        return Mockito.mock(FirebaseApp.class);
+    }
+
+    @Bean
+    @Primary
+    public FirebaseMessaging firebaseMessaging() {
+        return Mockito.mock(FirebaseMessaging.class);
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -54,6 +54,11 @@ cloud:
 server:
   port: 8080
 
+# Firebase (테스트용 더미 - 실제로는 Mock Bean 사용)
+firebase:
+  secret:
+    path: "firebase/dummy-key.json"
+
 # Logging (테스트 시 최소화)
 logging:
   level:


### PR DESCRIPTION
## 📝 작업 요약
- CI 테스트 환경에서 Firebase Mock 설정 추가
- CD 배포 환경에서 Firebase 환경변수 주입 방식 적용

## 🔗 관련 이슈
- #48

## 🛠 주요 변경 사항
- [x] 외부 API 또는 인프라(S3, FCM 등) 연동 설정

### 상세 변경 내용
1. **FirebaseConfig 개선**
   - 환경변수(`FIREBASE_SECRET_JSON`) 우선 읽기
   - 환경변수 없으면 기존처럼 classpath 파일에서 읽기
   - 로컬 개발 환경 영향 없음

2. **테스트 환경 개선**
   - `@Profile("!test")` 추가로 테스트 시 실제 Firebase 로드 방지
   - `TestFirebaseConfig` Mock 설정 추가

3. **CD 워크플로우 수정**
   - staging/prod 모두 `FIREBASE_SECRET_JSON` 환경변수 주입

## 🔍 리뷰 포인트
- **보안**: Firebase 키가 Docker 이미지에 포함되지 않고 환경변수로 주입됨

## 📸 테스트 결과
- 로컬 테스트 통과 (`./gradlew test` 성공)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? (N/A)

## 🛠 Troubleshooting
### 1. 문제 현상
- CI 테스트 실패: `BackendApplicationTests > contextLoads() FAILED`
- CD 배포 실패: Firebase 인증 키 파일을 찾지 못함

### 2. 원인 분석
- 테스트 환경에서 Firebase 키 파일이 없어 Bean 생성 실패
- Docker 이미지에 Firebase 키가 포함되지 않음 (public repo 보안상 의도적)

### 3. 해결 방안
- 테스트: Mock Firebase Bean 제공
- 배포: 환경변수로 Firebase JSON 주입 (이미지에 키 미포함으로 보안 유지)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 배포 환경에서 Firebase 자격증명 보안 처리 개선
  * 환경 변수 기반 설정으로 프로덕션 및 스테이징 배포 프로세스 강화

* **Tests**
  * Firebase 테스트 구성 개선으로 테스트 격리 및 신뢰성 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->