### PR TITLE
[Fix] ERD 자동 업데이트 워크플로우 main 트리거 제거

### DIFF
--- a/.github/workflows/update-erd.yml
+++ b/.github/workflows/update-erd.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - 'docs/ERD/WhoReads.sql'
     branches:
-      - main
       - develop
 
 jobs:


### PR DESCRIPTION
## 📝 작업 요약
- ERD 자동 업데이트 워크플로우(`update-erd.yml`)에서 `main` 브랜치 트리거를 제거

## 🔗 관련 이슈(있으면)
- #80

## 🛠 주요 변경 사항
- [x] `update-erd.yml`의 `on.push.branches`에서 `main` 제거 → `develop`에서만 동작

## 🔍 리뷰 포인트
- **배경**: `peter-evans/create-pull-request`가 `GITHUB_TOKEN`으로 PR을 생성하면, GitHub 보안 정책상 다른 워크플로우(CI)가 트리거되지 않음
- **해결**: `develop`에서만 ERD 자동 업데이트 → `develop → main` 머지 시 자연스럽게 반영되므로 `main` 트리거 불필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **작업**
  * 자동화된 데이터베이스 스키마 업데이트 워크플로우 트리거 변경

<!-- end of auto-generated comment: release notes by coderabbit.ai -->