### PR TITLE
[Fix] 헬스체크 엔드포인트 permitAll 설정

### DIFF
--- a/src/main/java/whoreads/backend/global/config/SecurityConfig.java
+++ b/src/main/java/whoreads/backend/global/config/SecurityConfig.java
@@ -19,6 +19,9 @@ public class SecurityConfig {
 
     private final String[] allowUris = {
             "/api/auth/**",
+            "/api/health",
+            "/api/books/**",
+            "/api/celebrities/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
             "/v3/api-docs/**",
@@ -40,8 +43,6 @@ public class SecurityConfig {
                 // 3. 인가 설정
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(allowUris).permitAll()
-                        .requestMatchers("/api/health").permitAll()
-                        .requestMatchers("/api/books/**", "/api/celebrities/**").permitAll()
                         .anyRequest().authenticated()
                 )
 


### PR DESCRIPTION
## 📝 작업 요약
- `/api/health` 헬스체크 엔드포인트에 대해 인증 없이 접근 가능하도록 SecurityConfig에 permitAll 추가

## 🔗 관련 이슈
- #104

## 🛠 주요 변경 사항
- [x] `SecurityConfig`에서 `/api/health` 경로를 `permitAll()`에 추가

## 🔍 리뷰 포인트
- **보안**: 헬스체크 경로만 열려 있고 나머지 인가 설정이 정상인지 확인해주세요.

## 📸 테스트 결과 (선택 사항)
- N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **체지 관리**
  * 헬스 체크 API("/api/health")와 도서 목록 및 상세 관련 API("/api/books/**"), 인물 관련 API("/api/celebrities/**")가 공개 접근 목록에 추가되어 인증 없이 접근할 수 있습니다.
  * 그 외 기존 보호 대상 엔드포인트들의 인증 요구사항은 변경되지 않았습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->