### PR TITLE
[Fix] prod 환경 JPA ddl-auto 설정 변경 및 헬스체크 인증 허용

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
 logging:


### PR DESCRIPTION
## 📝 작업 요약
- prod 환경 `ddl-auto`를 `validate`에서 `update`로 변경
- `/api/health` 헬스체크 엔드포인트 인증 없이 접근 허용
- SecurityConfig 공개 URI를 `allowUris` 배열로 통합 관리

## 🔗 관련 이슈
- #104

## 🛠 주요 변경 사항
- [x] `application-prod.yml`의 `ddl-auto: validate` → `update`로 변경
- [x] `/api/health` 엔드포인트 `permitAll` 설정
- [x] SecurityConfig 공개 URI 배열 통합 리팩토링

## 🔍 리뷰 포인트
- **로직**: N/A
- **성능**: N/A
- **보안**: `ddl-auto: update`로 변경 시 운영 DB 스키마 자동 변경 가능성 인지 필요

## 📸 테스트 결과 (선택 사항)
- N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* 프로덕션 환경의 데이터베이스 스키마 관리 설정이 변경되어 애플리케이션 시작 시 스키마가 자동으로 업데이트되도록 구성되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->