### PR TITLE
[Fix] prod 환경 JPA ddl-auto를 create-drop으로 변경

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: false
 
 logging:


### PR DESCRIPTION
## 📝 작업 요약
- prod 환경 `ddl-auto`를 `update`에서 `create-drop`으로 변경
- 운영 DB에 데이터가 없고 컬럼 불일치가 있어 스키마 재생성 필요

## 🔗 관련 이슈
- N/A

## 🛠 주요 변경 사항
- [x] `application-prod.yml`의 `ddl-auto: update` → `create-drop`으로 변경

## 🔍 리뷰 포인트
- **보안**: `create-drop`은 앱 종료 시 테이블을 삭제하므로, 데이터가 필요 없는 현재 단계에서만 사용해야 합니다. 안정화 후 `validate`로 되돌려야 합니다.

## 📸 테스트 결과 (선택 사항)
- N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?