### PR TITLE
[Deploy] 배포 버전 DB 정합성 확보

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     show-sql: false
 
 logging:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
     show-sql: false
 
 logging:


### PR DESCRIPTION
## 📝 작업 요약
- 배포 환경(`application-prod.yml`)의 JPA `ddl-auto` 설정을 `validate` → `create-drop`으로 변경

## 🔗 관련 이슈
- N/A

## 🛠 주요 변경 사항
- [x] `application-prod.yml`의 `ddl-auto: validate` → `create-drop`으로 변경

## 🔍 리뷰 포인트
- **배경**: 현재 배포 버전 DB에 저장된 데이터가 없고, 엔티티 변경으로 인해 기존 스키마와 컬럼 불일치가 발생하고 있습니다.
- **변경 이유**: `validate` 모드에서는 스키마 불일치 시 애플리케이션 기동이 실패하므로, `create-drop`으로 전환하여 기동 시 스키마를 재생성하도록 합니다.
- **주의**: `create-drop`은 애플리케이션 종료 시 테이블을 삭제합니다. 현재 초기 개발 단계에서만 사용하며, 데이터 유지가 필요한 시점에서 `validate` 또는 `none`으로 되돌려야 합니다.

## 📸 테스트 결과 (선택 사항)
- N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting
### 1. 문제 현상
- 배포 환경에서 엔티티와 DB 스키마 간 컬럼 불일치로 인해 `ddl-auto: validate` 모드에서 애플리케이션 기동 실패

### 2. 원인 분석
- 엔티티 변경 사항이 반영되지 않은 상태에서 `validate` 모드가 스키마 검증에 실패
- 배포 DB에 보존할 데이터가 없어 스키마 재생성이 가능한 상황

### 3. 해결 방안
- `ddl-auto`를 `create-drop`으로 변경하여 기동 시 스키마를 새로 생성
- 향후 데이터 축적 시 `validate` 또는 `none`으로 재변경 필요