### PR TITLE
[Feat] 팔로우 알림 대상자 추출 로직 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
+++ b/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.repository.query.Param;
 import whoreads.backend.domain.celebrity.entity.Celebrity;
 import whoreads.backend.domain.member.entity.Member;
 import whoreads.backend.domain.member.entity.MemberCelebrity;
+import whoreads.backend.domain.notification.dto.MemberTokenDTO;
 
 import java.util.List;
 
@@ -21,4 +22,11 @@ public interface MemberCelebrityRepository extends JpaRepository<MemberCelebrity
 
     // 언팔로우 기능을 위해 관계 삭제 메서드
     void deleteByMemberAndCelebrity(Member member, Celebrity celebrity);
+
+    @Query("SELECT DISTINCT mc.member.id AS memberId, mc.member.fcmToken AS fcmToken " +
+            "FROM MemberCelebrity mc " +
+            "WHERE mc.celebrity.id = :celebId " +
+            "AND mc.member.fcmToken IS NOT NULL " +
+            "AND mc.member.fcmToken <> ''")
+    List<MemberTokenDTO> findMemberTokensByCelebrityId(Long celebId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
@@ -4,8 +4,6 @@ import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.notification.enums.NotificationType;
 import whoreads.backend.domain.notification.event.NotificationEvent;
-import whoreads.backend.global.exception.CustomException;
-import whoreads.backend.global.exception.ErrorCode;
 
 import java.util.Map;
 
@@ -14,7 +12,8 @@ import java.util.Map;
 public class FcmMessageDTO {
     private final String title;
     private final String body;
-    private final String link;
+    private final Long celebrityId;
+    private final Long bookId;
     private final String type;
     private final Map<String, String> data;
 
@@ -23,11 +22,18 @@ public class FcmMessageDTO {
     * */
     public static FcmMessageDTO of(NotificationType type, NotificationEvent event) {
         String[] generated = type.generateMessage(event);
-        return FcmMessageDTO.builder()
+
+        FcmMessageDTO.FcmMessageDTOBuilder builder = FcmMessageDTO.builder()
                 .title(generated[0])
                 .body(generated[1])
-                .type(type.name()) // DB 저장용 타입 이름 (FOLLOW, ROUTINE 등)
-                .link(null)
-                .build();
+                .type(type.name()); // DB 저장용 타입 이름 (FOLLOW, ROUTINE 등)
+
+        if (event != null && type.equals(NotificationType.FOLLOW) &&
+                event instanceof NotificationEvent.FollowEvent followEvent)
+        {
+            builder.celebrityId(followEvent.celebId());
+            builder.bookId(followEvent.bookId());
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/whoreads/backend/domain/notification/event/NotificationEventListener.java
+++ b/src/main/java/whoreads/backend/domain/notification/event/NotificationEventListener.java
@@ -6,44 +6,26 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
-import whoreads.backend.domain.member.repository.MemberRepository;
+import whoreads.backend.domain.member.repository.MemberCelebrityRepository;
 import whoreads.backend.domain.notification.dto.FcmMessageDTO;
 import whoreads.backend.domain.notification.dto.MemberTokenDTO;
 import whoreads.backend.domain.notification.enums.NotificationType;
 import whoreads.backend.domain.notification.service.NotificationPushService;
 
 import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationEventListener {
     private final NotificationPushService pushService;
-    private final MemberRepository memberRepository;
+    private final MemberCelebrityRepository memberCelebrityRepository;
 
     @Async("WhoReadsAsyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleFollowEvent(NotificationEvent.FollowEvent event) {
         FcmMessageDTO message = FcmMessageDTO.of(NotificationType.FOLLOW, event);
-
-        /* todo: 해당 유명인을 팔로우 한 사람들 찾기
-            findById 사용시 N+1 문제 발생 -> 추후 유명인 팔로우 도메인 완성시 수정 예정!
-         */
-        List<Long> followList = List.of(2L,3L);
-        
-        // todo: 멤버 아이디가 들어있는 리스트로 가져오기 , 이것도 추후 구현
-        List<MemberTokenDTO> memberTokens = followList.stream()
-                .map(memberRepository::findById)
-                .flatMap(Optional::stream)
-                .filter(member -> member.getFcmToken() != null && !member.getFcmToken().isBlank())
-                .map(member -> new MemberTokenDTO() {  // 익명 객체로 인터페이스 구현
-                    @Override
-                    public Long getMemberId() { return member.getId(); }
-                    @Override
-                    public String getFcmToken() { return member.getFcmToken(); }
-                })
-                .collect(Collectors.toList());
+        List<MemberTokenDTO> memberTokens = memberCelebrityRepository
+                .findMemberTokensByCelebrityId(event.celebId());
         // 알림 기록할 수 있게 넣어주기
         pushService.sendMulticast(memberTokens,message);
     }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
@@ -53,7 +53,6 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
                 .title(dto.getTitle())
                 .body(dto.getBody())
                 .type(NotificationType.valueOf(dto.getType()))
-                .link(dto.getLink())
                 .build();
         notificationHistoryRepository.save(history);
     }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -13,7 +13,6 @@ import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
 import java.util.List;
-import java.util.Optional;
 
 
 @Service
@@ -69,7 +68,6 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                 .putData("title", dto.getTitle())
                 .putData("body", dto.getBody())
                 .putData("type",dto.getType())
-                .putData("link", Optional.ofNullable(dto.getLink()).orElse(""))
                 .build();
     }
     
@@ -81,7 +79,7 @@ public class NotificationPushServiceImpl implements NotificationPushService {
         for (int i = 0; i < memberTokens.size(); i += FCM_BATCH_SIZE) {
             List<MemberTokenDTO> subList = memberTokens.subList(i, Math.min(i + FCM_BATCH_SIZE, memberTokens.size()));
 
-            MulticastMessage message = MulticastMessage.builder()
+            MulticastMessage.Builder builder = MulticastMessage.builder()
                     .addAllTokens(subList.stream()
                             .map(MemberTokenDTO::getFcmToken)
                             .toList())
@@ -98,9 +96,14 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                             .build())
                     .putData("title", dto.getTitle())
                     .putData("body", dto.getBody())
-                    .putData("type", dto.getType())
-                    .putData("link", Optional.ofNullable(dto.getLink()).orElse(""))
-                    .build();
+                    .putData("type", dto.getType());
+            if (dto.getCelebrityId()!=null && dto.getBookId()!=null)
+            {
+                builder
+                        .putData("celebrity_id", String.valueOf(dto.getCelebrityId()))
+                        .putData("book_id", String.valueOf(dto.getBookId()));
+            }
+            MulticastMessage message = builder.build();
             try {
                 BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
                 for (int j = 0; j< response.getResponses().size();j++)


### PR DESCRIPTION
## 📝 작업 요약
 - 팔로우 알림 대상자 추출 로직 추가

## 🔗 관련 이슈(있으면)
- #36 

## 🛠 주요 변경 사항
- Notification > FcmDTO에 bookId, celebrityId 추가
- Notification > FollowEventListner에 실제 멤버 팔로우 로직 추가

## 📸 테스트 결과 (선택 사항)

- 실제 팔로우 한 멤버에게 알림이 갔음

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 연예인 팔로우 알림 시스템이 개선되어 더욱 정밀한 타겟팅이 가능해졌습니다.

* **개선 사항**
  * 알림 전송 성능이 최적화되었습니다.
  * 알림에 셀럽 및 도서 정보가 포함되어 더 유용한 정보 제공이 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->