### PR TITLE
[Feat] GET방식 DNA 테스트 결과 API 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/celebrity/entity/Celebrity.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/entity/Celebrity.java
@@ -28,6 +28,9 @@ public class Celebrity extends BaseEntity {
     @Column(name = "short_bio", nullable = false)
     private String shortBio; // 한줄 소개
 
+    @Column(columnDefinition = "TEXT")
+    private String resultComment;
+
     // 직업 태그 (가수, 배우 등) - 필터링용
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(

--- a/src/main/java/whoreads/backend/domain/celebrity/repository/CelebrityRepository.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/repository/CelebrityRepository.java
@@ -31,4 +31,6 @@ public interface CelebrityRepository extends JpaRepository<Celebrity, Long> {
             "LEFT JOIN FETCH cb.book " + // Book까지 한꺼번에 긁어와야 함!
             "WHERE c.id IN :ids")
     List<Celebrity> findAllByIdWithBooks(@Param("ids") List<Long> ids);
+
+    Optional<Celebrity> findByName(String celebrityName);
 }

--- a/src/main/java/whoreads/backend/domain/dna/controller/DnaController.java
+++ b/src/main/java/whoreads/backend/domain/dna/controller/DnaController.java
@@ -41,4 +41,11 @@ public class DnaController implements DnaControllerDocs {
         return ApiResponse.success("테스트 결과가 성공적으로 나왔습니다", result);
     }
 
+    @GetMapping("/results")
+    public ApiResponse<DnaResDto.Result> getMyDnaResult(@AuthenticationPrincipal Long memberId) {
+        DnaResDto.Result result = dnaService.getTestResult(memberId);
+
+        return ApiResponse.success("DNA 테스트 결과를 조회했습니다.", result);
+    }
+
 }

--- a/src/main/java/whoreads/backend/domain/dna/controller/DnaControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/dna/controller/DnaControllerDocs.java
@@ -2,6 +2,7 @@ package whoreads.backend.domain.dna.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -39,4 +40,11 @@ public interface DnaControllerDocs {
                     "- **selected_option_ids**: 사용자가 Q2~Q5에서 선택한 보기의 id 값들"
     )
     ApiResponse<DnaResDto.Result> calculateResult(@RequestBody @Valid DnaReqDto.Submit request, @AuthenticationPrincipal Long memberId);
+
+    @Operation(summary = "테스트 결과 API")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "DNA 테스트 결과가 존재하지 않습니다.")
+    })
+    ApiResponse<DnaResDto.Result> getMyDnaResult(@AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
+++ b/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
@@ -15,6 +15,7 @@ import whoreads.backend.domain.dna.enums.GenreCode;
 import whoreads.backend.domain.dna.enums.TrackCode;
 import whoreads.backend.domain.dna.repository.DnaOptionRepository;
 import whoreads.backend.domain.dna.repository.DnaQuestionRepository;
+import whoreads.backend.domain.dna.repository.DnaResultRepository;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
@@ -30,9 +31,8 @@ public class DnaService {
 
     private final DnaQuestionRepository dnaQuestionRepository;
     private final DnaOptionRepository dnaOptionRepository;
+    private final DnaResultRepository dnaResultRepository;
     private final CelebrityRepository celebrityRepository;
-//    private final CelebrityRepository celebrityRepository;
-//    private final DnaResultRepository resultRepository;
 
     public DnaResDto.Question getRootQuestion() {
         // Q1 질문
@@ -66,9 +66,13 @@ public class DnaService {
     /**
      * [최종 목적지] 독서 DNA 테스트 제출 및 결과 반환
      */
+    @Transactional
     public DnaResDto.Result submitTest(DnaReqDto.Submit request) {
         // 1. 실시간으로 상위 5명 Pool 추출 (아래 메서드 참고)
-        List<Celebrity> pool = getTop5CelebritiesOnTheFly(request.trackCode());
+        List<Long> poolIds = getTargetGenresForTrack(request.trackCode());
+
+        // DB에서 해당 5명의 인물 정보 조회
+        List<Celebrity> pool = celebrityRepository.findAllById(poolIds);
 
         // 2. 유저 답변(Q2~Q5) 장르 점수 합산
         Map<GenreCode, Integer> userScores = calculateMemberGenreScores(request.selectedOptionIds());
@@ -94,67 +98,22 @@ public class DnaService {
         if (winner == null)
             throw new RuntimeException("매칭된 인물이 없습니다.");
 
-        // 4. 단 한 명의 결과를 DTO로 변환하여 반환
-        return DnaConverter.toResultDto(winner, request.trackCode(), winner.getShortBio());
-    }
+        // 하드코딩된 RESULT_COMMENTS 맵에서 이 인물+트랙에 맞는 문구 추출
+        String finalCommentary = getCommentary(winner.getId(), request.trackCode());
 
-    /**
-     * [핵심 로직] DB 컬럼 없이 매핑 테이블로 상위 5명 뽑기
-     */
-    public List<Celebrity> getTop5CelebritiesOnTheFly(TrackCode trackCode) {
-        List<Celebrity> allCelebrities = celebrityRepository.findAll();
-
-        // 랭킹 정보를 담을 리스트 (여기에 CelebrityRankDto가 들어갑니다)
-        List<CelebrityRankDto> rankingList = new ArrayList<>();
-
-        // 트랙별 타겟 장르 이름 리스트 (예: "문학", "에세이·회고")
-        List<String> targetGenreNames = getTargetGenresForTrack(trackCode);
-
-        for (Celebrity celebrity : allCelebrities) {
-            List<CelebrityBook> books = celebrity.getCelebrityBookList();
-            int totalCount = books.size();
-
-            // 최소 권수 필터 (FOCUS만 10권, 나머지 5권)
-            int minCount = (trackCode == TrackCode.FOCUS) ? 10 : 5;
-            if (totalCount < minCount)
-                continue;
-
-            // 해당 트랙 장르 권수 카운트
-            int targetCount = 0;
-            for (CelebrityBook celebrityBook : books) {
-                if (targetGenreNames.contains(celebrityBook.getBook().getGenre())) {
-                    targetCount++;
-                }
-            }
-
-            double ratio = (double) targetCount / totalCount;
-
-            // CelebrityRankDto를 사용해서 인물과 점수를 묶어둠
-            rankingList.add(new CelebrityRankDto(celebrity, ratio));
-        }
-
-        // 랭킹 리스트를 비율(ratio) 기준으로 내림차순 정렬
-        rankingList.sort((o1, o2) -> Double.compare(o2.ratio(), o1.ratio()));
-
-        // 정렬된 결과에서 상위 5명만 Celebrity 객체로 추출
-        List<Celebrity> top5 = new ArrayList<>();
-        for (int i = 0; i < Math.min(5, rankingList.size()); i++) {
-            top5.add(rankingList.get(i).celebrity());
-        }
-
-        return top5;
+        return DnaConverter.toResultDto(winner, request.trackCode(), finalCommentary);
     }
 
     /**
      * 트랙별 중점 장르 매핑 (DB의 String 장르값과 정확히 일치해야 함)
      */
-    private List<String> getTargetGenresForTrack(TrackCode trackCode) {
+    private List<Long> getTargetGenresForTrack(TrackCode trackCode) {
         return switch (trackCode) {
-            case COMFORT -> List.of("문학", "에세이·회고");
-            case HABIT -> List.of("자기계발·심리", "경제·경영·커리어");
-            case CAREER -> List.of("경제·경영·커리어", "인문·철학", "사회·역사");
-            case INSIGHT -> List.of("인문·철학", "사회·역사", "과학·기술");
-            case FOCUS -> List.of("재미·몰입");
+            case COMFORT -> List.of(37L, 27L, 33L, 70L, 35L);
+            case HABIT -> List.of(73L, 104L, 102L, 7L, 95L);
+            case CAREER -> List.of(59L, 97L, 102L, 26L, 6L);
+            case INSIGHT -> List.of(59L, 17L, 97L, 26L, 4L);
+            case FOCUS -> List.of(33L, 13L, 2L, 25L, 8L);
         };
     }
 
@@ -167,7 +126,7 @@ public class DnaService {
             int count = 0;
             for (CelebrityBook cb : books) {
                 // Book의 String 장르와 GenreCode의 description(한글) 비교
-                if (cb.getBook().getGenre().equals(code.getDescription())) {
+                if (cb.getBook().getGenre().equals(code.getDescription().trim())) {
                     count++;
                 }
             }
@@ -206,4 +165,98 @@ public class DnaService {
 
     // 임시 랭킹 저장용 내부 클래스 (레코드는 getter 없이 .ratio()로 바로 접근 가능)
     private record CelebrityRankDto(Celebrity celebrity, double ratio) {}
+
+    private static final Map<String, String> RESULT_COMMENTS = new HashMap<>() {{
+        // === 1. COMFORT (마음 정리 / 위로) ===
+        put("37_COMFORT", """
+        바쁜 일상 속에서도 혼자만의 독서 시간을 통해 마음과 생각을 정리해 온 인물이에요.
+        지금의 당신처럼, 감정을 서두르지 않고 나 자신에게 집중하는 독서가 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("27_COMFORT", """
+        서사와 인물의 밀도를 높이기 위해 문학에서 끊임없이 영감을 받아온 영화 감독이에요.
+        지금의 당신처럼, 이야기 속 인물과 마음을 깊이 들여다보며 나 자신의 마음을 알아가고자 하는 독서가 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("33_COMFORT", """
+        이야기 구조와 언어 감각을 다져온 소설가로, 다양한 문학과 논픽션을 통해 사유와 상상의 폭을 넓혀온 인물이에요.
+        지금의 당신처럼, 감정을 설명하려 하기보다 이야기 속에 잠시 머물며 마음을 정리하고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("70_COMFORT", """
+        음악과 감정을 더 섬세하게 표현하기 위해 책과 영화, 문학을 통해 자신의 감각을 꾸준히 다듬어 온 인물이에요.
+        지금의 당신처럼, 감정을 바로 말로 정리하기보다 천천히 느끼고 표현을 가다듬는 시간이 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("35_COMFORT", """
+        문학을 통해 일상의 감정과 생각을 차분히 정리해 온 창작자예요. 책방을 운영하며, 읽는 시간 자체를 사유의 과정으로 만들어 온 인물이기도 해요.
+        지금의 당신처럼, 마음을 서둘러 결론 내리기보다 일상의 언어로 천천히 정리하고 싶을 때 이 인물의 추천 책을 읽어 보세요.""");
+
+        // === 2. HABIT (실행력 / 습관) ===
+        put("73_HABIT", """
+        잠재력을 실현하는 행동과 사고의 원리를 탐구해 온 동기부여 연설가이자 자기계발 저자예요. 심리·성공·자기 혁신에 관한 독서를 통해 변화를 실행으로 옮기는 방법을 꾸준히 다뤄왔어요.
+        지금의 당신처럼, 결심을 행동으로 바꾸고 지속 가능한 습관을 만들고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("104_HABIT", """
+        명상과 자기 규율을 위해 철학적 독서를 일상의 루틴처럼 실천해 온 인물이에요. 생각을 다듬는 시간을 통해 삶의 리듬과 행동의 기준을 만들어 온 방식이 특징이에요.
+        지금의 당신처럼, 의욕보다 먼저 지속할 수 있는 습관과 구조가 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("102_HABIT", """
+        기술과 사회 변화의 흐름을 이해하기 위해 비즈니스와 산업 관련 독서를 이어온 배우이자 투자자예요. 새로운 흐름을 빠르게 읽고 판단을 행동으로 옮기는 기준을 책에서 다져온 인물이에요.
+        지금의 당신처럼, 막연한 동기보다 현실적인 판단과 실행의 근거가 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("7_HABIT", """
+        성과 중심의 성공관을 다시 정의하며, 일과 삶의 균형을 탐구해 온 미디어 기업가이자 작가예요. 번아웃을 계기로 지속 가능한 실행과 회복의 리듬을 독서를 통해 정리해 온 인물이에요.
+        지금의 당신처럼, 더 열심히 하기보다 오래 지속할 수 있는 방식의 실행이 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("95_HABIT", """
+        사회 문제를 구조적으로 이해하고 실질적인 변화를 만들기 위해 폭넓은 비즈니스·사회 분야 독서를 이어온 인물이에요. 책을 통해 가치와 실행을 연결하는 기준을 다져왔어요.
+        지금의 당신처럼, 의미 있는 목표를 꾸준한 행동으로 옮기고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+
+        // === 3. CAREER (커리어 / 시야 넓히기) ===
+        put("59_CAREER", """
+        유머와 풍자를 통해 사회와 개인의 경계를 끊임없이 질문해 온 코미디언이자 작가예요. 자신의 경험을 출발점으로 권력, 차별, 책임 같은 주제를 정면으로 다뤄온 독서와 사유가 특징이에요.
+        지금의 당신처럼, 하나의 정답보다 세상과 커리어를 여러 각도에서 바라보고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("97_CAREER", """
+        사회 구조와 권력, 개인의 선택을 끊임없이 질문해 온 코미디언이자 작가예요. 정치·철학·자기 성찰을 넘나드는 독서를 통해 기존의 성공과 커리어 관념을 다시 생각하게 만드는 시선을 보여줘요.
+        지금의 당신처럼, 주어진 틀 안에서 답을 찾기보다 다른 질문을 통해 나만의 방향을 고민하고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("102_CAREER", """
+        기술과 산업, 사회 변화의 흐름을 이해하기 위해 비즈니스와 혁신 관련 독서를 이어온 배우이자 투자자예요. 단기 성과보다 세상이 어디로 향하는지 읽는 시선을 통해 커리어의 선택지를 넓혀온 인물이에요.
+        지금의 당신처럼, 하나의 직무보다 더 큰 맥락 속에서 커리어를 바라보고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("26_CAREER", """
+        학습과 사고의 구조를 정리하며, 개인의 선택을 사회와 시대의 맥락 속에서 바라보는 대한민국의 스타 강사예요. 지식을 쌓는 데서 그치지 않고 어떤 기준으로 생각하고 판단할지를 책을 통해 다뤄온 인물이에요.
+        지금의 당신처럼, 눈앞의 목표를 넘어서 스스로의 방향과 기준을 다시 세우고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("6_CAREER", """
+        다양한 분야의 사람들과 대화를 이어오며, 과학·사회·문화 전반을 폭넓게 탐구해 온 인물이에요. 정답을 제시하기보다 서로 다른 관점을 연결하며 생각의 범위를 넓혀온 독서가 특징이에요.
+        지금의 당신처럼, 하나의 길에 갇히기보다 여러 시선을 통해 커리어의 가능성을 탐색하고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+
+        // === 4. INSIGHT (사고 확장 / 관점) ===
+        put("59_INSIGHT", """
+        유머와 풍자를 통해 당연하게 여겨온 전제와 권력을 끊임없이 의심해 온 작가이자 코미디언이에요. 개인의 경험을 출발점으로 사회적 이슈를 다른 각도에서 해석하는 독서와 사유를 이어온 인물이에요.
+        지금의 당신처럼, 정답을 찾기보다 생각의 프레임을 바꾸는 질문이 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("17_INSIGHT", """
+        진화생물학자의 시선으로 인간 사회와 자연의 관계를 넓게 바라봐 온 인물이에요. 과학을 출발점으로 당연하게 여겨온 생각과 제도를 다시 보게 만드는 독서를 이어왔어요.
+        지금의 당신처럼, 익숙한 판단을 잠시 내려놓고 다른 기준으로 세상을 해석해 보고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("97_INSIGHT", """
+        개인의 경험과 사회 구조를 연결하며 권력, 성공, 자유에 대한 전제를 끊임없이 질문해 온 인물이에요. 철학과 정치, 자기 성찰을 넘나드는 독서를 통해 익숙한 담론을 다른 각도에서 바라보는 시선을 키워왔어요.
+        지금의 당신처럼, 정답에 기대기보다 의심하고 다시 질문하는 관점이 필요할 때 이 인물의 추천 책을 읽어보세요.""");
+        put("26_INSIGHT", """
+        지식과 사고의 구조를 정리하며, 개인의 선택을 사회와 시대의 맥락 속에서 바라보게 하는 대한민국의 스타 강사예요. 단편적인 정보보다 생각하는 기준을 세우는 독서를 통해 관점을 확장해 온 인물이에요.
+        지금의 당신처럼, 익숙한 판단을 넘어서 스스로 사고의 틀을 점검하고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("4_INSIGHT", """
+        우주와 과학을 출발점으로 인간의 인식과 사고를 넓혀 온 천체물리학자이자 과학 커뮤니케이터예요. 복잡한 개념을 일상의 언어로 풀어내며 세상을 바라보는 기준 자체를 다시 생각하게 만드는 독서를 이어온 인물이에요.
+        지금의 당신처럼, 익숙한 세계를 넘어 더 넓은 관점에서 질문하고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+
+        // === 5. FOCUS (재미 / 몰입) ===
+        put("33_FOCUS", """
+        이야기의 힘으로 독자를 단숨에 끌어들이는 소설가예요. 장르를 넘나드는 서사와 생생한 인물 묘사를 통해 읽는 순간에 깊이 몰입하게 만드는 독서 경험을 꾸준히 만들어 온 인물이에요.
+        지금의 당신처럼, 의미를 따지기보다 이야기에 빠져드는 즐거움을 온전히 느끼고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("13_FOCUS", """
+        강한 서사와 매력적인 인물을 중심으로 이야기의 몰입도를 중요하게 여겨 온 배우이자 프로듀서예요. 읽는 순간 바로 빠져들 수 있는 작품들을 꾸준히 선택하며 재미와 완성도를 모두 갖춘 독서 경험을 만들어 온 인물이에요.
+        지금의 당신처럼, 부담 없이 책을 펼치고 끝까지 읽고 싶어지는 재미를 느끼고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("2_FOCUS", """
+        현실과 환상을 자연스럽게 넘나들며 이야기 그 자체의 힘을 믿어온 작가예요. 신화와 판타지를 바탕으로 한 서사를 통해 상상 속 세계에 깊이 빠져들게 만드는 독서 경험을 만들어 온 인물이에요.
+        지금의 당신처럼, 생각을 잠시 내려두고 이야기의 흐름에 몸을 맡기고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("25_FOCUS", """
+        이야기의 힘으로 사람들의 마음을 사로잡아 온 미디어 아이콘이에요. 강한 서사와 공감 가는 인물을 중심으로 한 번 펼치면 끝까지 읽게 만드는 책들을 꾸준히 선택해 온 인물이에요.
+        지금의 당신처럼, 의미를 해석하기보다 읽는 즐거움에 온전히 빠지고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+        put("8_FOCUS", """
+        이야기의 전개와 캐릭터에 몰입하는 즐거움을 중요하게 여기는 대한민국의 유튜버예요. 가볍게 시작해도 끝까지 읽게 만드는 서사를 중심으로 재미에 충실한 독서 경험을 꾸준히 즐겨온 인물이에요.
+        지금의 당신처럼, 복잡한 해석 없이 순수하게 읽는 재미에 빠지고 싶을 때 이 인물의 추천 책을 읽어보세요.""");
+    }};
+
+    // 2. 문구 가져오는 헬퍼 메서드
+    private String getCommentary(Long celebrityId, TrackCode trackCode) {
+        String key = celebrityId + "_" + trackCode.name();
+        // 만약 지도에 없으면 "기본 문구"를 반환하도록 설정
+        return RESULT_COMMENTS.getOrDefault(key, "WhoReads가 추천하는 인물입니다. 인물의 추천 도서를 통해 새로운 영감을 얻어보세요.");
+    }
 }

--- a/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
+++ b/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
@@ -70,6 +70,24 @@
             return new DnaResDto.TrackQuestion(trackCode, questionsDtos);
         }
 
+        public DnaResDto.Result getTestResult(Long memberId) {
+            Member member = memberRepository.findById(memberId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+
+            if (member.getDnaType() == null)
+                throw new CustomException(ErrorCode.DNA_TEST_NOT_COMPLETED);
+
+            TrackCode trackCode = TrackCode.valueOf(member.getDnaType());
+            String celebrityName = member.getDnaTypeName();
+
+            Celebrity celebrity = celebrityRepository.findByName(celebrityName)
+                    .orElseThrow(() -> new CustomException(ErrorCode.DNA_TEST_NOT_FOUND_RESULT_CELEBRITY));
+
+            String finalCommentary = getCommentary(celebrity.getId(), trackCode);
+
+            return DnaConverter.toResultDto(celebrity, trackCode, finalCommentary);
+        }
+
         /**
          * [최종 목적지] 독서 DNA 테스트 제출 및 결과 반환
          */

--- a/src/main/java/whoreads/backend/global/exception/ErrorCode.java
+++ b/src/main/java/whoreads/backend/global/exception/ErrorCode.java
@@ -44,8 +44,9 @@ public enum ErrorCode {
     QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "인용을 찾을 수 없습니다."),
 
     // DNA
+    DNA_TEST_NOT_FOUND_RESULT_CELEBRITY(HttpStatus.NOT_FOUND, "매칭된 인물 정보를 찾을 수 없습니다."),
     DNA_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DNA 테스트 질문을 찾을 수 없습니다."),
-    DNA_TEST_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "독서 DNA 테스트를 완료해주세요."),
+    DNA_TEST_NOT_COMPLETED(HttpStatus.NOT_FOUND, "독서 DNA 테스트를 완료해주세요."),
 
     // Reading Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "독서 세션을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📝 작업 요약
- GET방식 DNA 테스트 결과 API 추가

## 🔗 관련 이슈(있으면)
- #58 

## 🛠 주요 변경 사항
- DnaControllerDocs: GET /api/dna/results에 대한 Swagger 명세 추가
- DnaController: 토큰 기반으로 본인의 DNA 결과를 조회하는 GET 메서드 추가
- DnaService: GET 방식 로직 추가

## 🔍 리뷰 포인트
- 로직: DNA 테스트를 완료하지 않은 사용자가 조회 시 404(DNA_RESULT_NOT_FOUND) 예외가 정상적으로 발생하는지 확인 부탁드립니다.
- 성능: 새로운 서비스 로직에서 기존의 getCommentary와 DnaConverter를 재활용하여 코드 중복을 최소화했습니다.

## 📸 테스트 결과 (선택 사항)
테스트 전
<img width="825" height="534" alt="image" src="https://github.com/user-attachments/assets/255dd886-8b09-44d6-b9f0-34fdf71a2ea7" />

테스트 후
<img width="906" height="661" alt="image" src="https://github.com/user-attachments/assets/967f3d6f-93ef-494f-b301-48624237004b" />


## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * DNA 테스트 결과 조회 기능 추가: 사용자가 이전에 계산한 본인의 DNA 테스트 결과를 언제든지 조회할 수 있습니다. 결과에는 매칭된 인물 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->