### PR TITLE
feat: 주제별 추천 책 목록 조회 API 구현

### DIFF
--- a/src/main/java/whoreads/backend/domain/book/controller/BookController.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/BookController.java
@@ -13,6 +13,7 @@ import whoreads.backend.domain.book.dto.BookResponse;
 import whoreads.backend.domain.book.entity.Book;
 import whoreads.backend.domain.book.service.AladinBookService;
 import whoreads.backend.domain.book.service.BookService;
+import whoreads.backend.domain.topic.entity.TopicTag;
 import whoreads.backend.global.response.ApiResponse;
 
 import java.util.List;
@@ -81,5 +82,20 @@ public class BookController implements BookControllerDocs {
             return (Long) authentication.getPrincipal();
         }
         return null;
+    }
+
+    @Override
+    @GetMapping("/themes/{theme}")
+    public ResponseEntity<List<BookResponse>> getBooksByTheme(
+            @PathVariable TopicTag theme,
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        List<Book> books = bookService.getBooksByTheme(theme, limit);
+
+        List<BookResponse> response = books.stream()
+                .map(BookResponse::from)
+                .collect(Collectors.toList());
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import whoreads.backend.domain.book.dto.BookDetailResponse;
 import whoreads.backend.domain.book.dto.BookRequest;
 import whoreads.backend.domain.book.dto.BookResponse;
+import whoreads.backend.domain.topic.entity.TopicTag;
 
 import java.util.List;
 
@@ -45,5 +46,11 @@ public interface BookControllerDocs {
     })
     whoreads.backend.global.response.ApiResponse<BookDetailResponse> getBookDetail(
             @Parameter(description = "책 ID") @PathVariable Long bookId
+    );
+
+    @Operation(summary = "주제별 추천 책 목록 조회", description = "특정 주제(SOCIETY, HUMAN_UNDERSTANDING 등)에 맞는 유명인 추천 책 목록을 조회합니다.")
+    ResponseEntity<List<BookResponse>> getBooksByTheme(
+            @Parameter(description = "주제 태그 (Enum 값)") @PathVariable TopicTag theme,
+            @Parameter(description = "가져올 책 개수 (기본값 20)") @RequestParam(defaultValue = "20") int limit
     );
 }

--- a/src/main/java/whoreads/backend/domain/book/service/BookService.java
+++ b/src/main/java/whoreads/backend/domain/book/service/BookService.java
@@ -14,6 +14,8 @@ import whoreads.backend.domain.book.repository.BookRepository;
 import whoreads.backend.domain.library.repository.UserBookRepository;
 import whoreads.backend.domain.quote.entity.QuoteSource;
 import whoreads.backend.domain.quote.repository.QuoteSourceRepository;
+import whoreads.backend.domain.topic.entity.TopicTag;
+import whoreads.backend.domain.topic.repository.TopicBookRepository;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
@@ -32,6 +34,7 @@ public class BookService {
     private final BookQuoteRepository bookQuoteRepository;
     private final QuoteSourceRepository quoteSourceRepository;
     private final UserBookRepository userBookRepository;
+    private final TopicBookRepository topicBookRepository;
 
     // 책 상세 조회
     public Book getBook(Long bookId) {
@@ -99,5 +102,16 @@ public class BookService {
         }
 
         return response;
+    }
+
+    // 주제별 책 조회 로직
+    public List<Book> getBooksByTheme(TopicTag theme, int limit) {
+        // 프론트에서 TOP_20을 요청했을 땐 기존 로직 재사용
+        if (theme == TopicTag.TOP_20) {
+            return getMostRecommendedBooks(limit);
+        }
+
+        // 그 외의 주제들은 TopicBook 매핑 테이블에서 조회
+        return topicBookRepository.findBooksByThemeName(theme, PageRequest.of(0, limit));
     }
 }

--- a/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
+++ b/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
@@ -1,10 +1,13 @@
 package whoreads.backend.domain.topic.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import whoreads.backend.domain.book.entity.Book;
 import whoreads.backend.domain.topic.entity.Topic;
 import whoreads.backend.domain.topic.entity.TopicBook;
+import whoreads.backend.domain.topic.entity.TopicTag;
 
 import java.util.List;
 
@@ -13,4 +16,8 @@ public interface TopicBookRepository extends JpaRepository<TopicBook, Long> {
     // 특정 주제에 연결된 책들 조회 (Book 정보도 같이 가져옴 - N+1 방지)
     @Query("SELECT tb FROM TopicBook tb JOIN FETCH tb.book WHERE tb.topic = :topic")
     List<TopicBook> findByTopicWithFetchJoin(@Param("topic") Topic topic);
+    
+    // TopicBook과 연관된 Topic을 조인해서 Enum(TopicTag) 이름으로 바로 필터링하고, Book만 가져옴
+    @Query("SELECT tb.book FROM TopicBook tb JOIN tb.topic t WHERE t.name = :theme")
+    List<Book> findBooksByThemeName(@Param("theme") TopicTag theme, Pageable pageable);
 }


### PR DESCRIPTION
## 📝 작업 요약
- 가장 많이 추천한 책 20 이외에 각 주제별 api 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **새로운 기능**
  * 테마별 책 조회 API 엔드포인트가 추가되었습니다. 특정 테마의 추천 책들을 조회할 수 있으며, limit 파라미터(기본값: 20개)로 조회 개수를 제한할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->