### PR TITLE
[Fix] 서재 책 목록 조회 응답에 userBookId 필드 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/library/dto/UserBookResponse.java
+++ b/src/main/java/whoreads/backend/domain/library/dto/UserBookResponse.java
@@ -33,6 +33,7 @@ public class UserBookResponse {
     @Getter
     @Builder
     public static class SimpleBook {
+        private Long userBookId;
         private BookResponse book;
         private Integer readingPage;
         private Integer celebritiesCount;
@@ -40,6 +41,7 @@ public class UserBookResponse {
 
         public static SimpleBook from(UserBook userBook, List<CelebritySummary> celebrities) {
             return SimpleBook.builder()
+                    .userBookId(userBook.getId())
                     .book(BookResponse.from(userBook.getBook()))
                     .readingPage(userBook.getReadingPage())
                     .celebritiesCount(celebrities.size())


### PR DESCRIPTION
## 📝 작업 요약
- `GET /api/me/library/list` 서재 책 목록 조회 응답에 `userBookId` 필드 추가

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] `UserBookResponse.SimpleBook`에 `userBookId` 필드 추가
- [x] `SimpleBook.from()` 팩토리 메서드에서 `userBook.getId()` 매핑

## 🔍 리뷰 포인트
- **로직**: 비즈니스 예외 상황(Exception) 처리가 적절하게 되어 있나요?
- **성능**: DB 쿼리 실행 시 N+1 문제나 비효율적인 연산이 있지는 않나요?
- **보안**: API 권한 체크나 민감 정보 노출 위험은 없는지 봐주세요.

## 📸 테스트 결과 (선택 사항)
- N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* 사용자별 도서 추적 개선: 각 사용자의 도서 기록을 고유하게 식별할 수 있는 기능이 추가되었습니다.
* 도서 정보 확장: 도서와 연관된 유명인 정보가 포함되어 더욱 풍부한 도서 데이터를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->