### PR TITLE
[Fix] 알림 읽음 처리 정책 변경

### DIFF
--- a/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
+++ b/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
@@ -25,7 +25,11 @@ public interface MemberCelebrityRepository extends JpaRepository<MemberCelebrity
 
     @Query("SELECT DISTINCT mc.member.id AS memberId, mc.member.fcmToken AS fcmToken " +
             "FROM MemberCelebrity mc " +
-            "WHERE mc.celebrity.id = :celebId " +
+            "JOIN mc.member m " +
+            "LEFT JOIN NotificationSetting ns ON ns.member = m " +
+            "AND ns.type = 'FOLLOW' " +
+            "Where mc.celebrity.id = :celebId " +
+            "AND (ns.id IS NULL OR ns.isEnabled = true) " +
             "AND mc.member.fcmToken IS NOT NULL " +
             "AND mc.member.fcmToken <> ''")
     List<MemberTokenDTO> findMemberTokensByCelebrityId(Long celebId);

--- a/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
@@ -55,7 +55,7 @@ public class NotificationController implements NotificationControllerDocs {
                 notificationHistoryService.readNotification(memberId,notificationId)
         );
     }
-    @PostMapping("/{notification_id}/read-all")
+    @PostMapping("/read-all")
     public ApiResponse<Void> readAllNotifications (
             @AuthenticationPrincipal Long memberId
     ){

--- a/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
@@ -33,8 +33,8 @@ public class NotificationController implements NotificationControllerDocs {
                 (fcmToken,FcmMessageDTO.of(NotificationType.ROUTINE,null));
         return ApiResponse.success("알림이 전송되었습니다.");
     }
-    // 미수신 알림 조회
-    @GetMapping("/inbox")
+    // 전체 알림 조회
+    @GetMapping()
     public ApiResponse<NotificationResDTO.TotalInboxDTO> getNotifications (
             @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) Long cursor,
@@ -45,13 +45,32 @@ public class NotificationController implements NotificationControllerDocs {
                 notificationHistoryService.getNotificationHistory(memberId,cursor,size)
        );
     }
-    // 알림 수신 처리 ( 삭제 )
-    @DeleteMapping("/inbox/{notification_id}")
+    @PatchMapping("/{notification_id}/read")
+    public ApiResponse<NotificationResDTO.HistoryDTO> readNotification (
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable(value = "notification_id") Long notificationId
+    ){
+        return ApiResponse.success(
+                "사용자의 알림을 읽음 처리 하였습니다.",
+                notificationHistoryService.readNotification(memberId,notificationId)
+        );
+    }
+    @PostMapping("/{notification_id}/read-all")
+    public ApiResponse<Void> readAllNotifications (
+            @AuthenticationPrincipal Long memberId
+    ){
+        return ApiResponse.success(
+                "사용자의 알림을 읽음 처리 하였습니다.",
+                notificationHistoryService.readAllNotifications(memberId)
+        );
+    }
+    // 알림 삭제 처리
+    @DeleteMapping("/{notification_id}")
     public ApiResponse<Void> deleteNotification(
             @AuthenticationPrincipal Long memberId,
             @PathVariable(value = "notification_id") Long notificationId
     ){
-        notificationHistoryService.readNotification(memberId,notificationId);
+        notificationHistoryService.deleteNotification(memberId,notificationId);
         return ApiResponse.success("알림을 성공적으로 삭제하였습니다.");
     }
 }

--- a/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -33,7 +33,7 @@ public interface NotificationControllerDocs {
     );
     @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
     })
     whoreads.backend.global.response.ApiResponse<NotificationResDTO.HistoryDTO> readNotification(
             @AuthenticationPrincipal Long memberId,
@@ -41,13 +41,13 @@ public interface NotificationControllerDocs {
     );
     @Operation(summary = "모든 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
     })
     whoreads.backend.global.response.ApiResponse<Void> readAllNotifications(
             @AuthenticationPrincipal Long memberId
     );
 
-    @Operation(summary = "알림 삭제", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
+    @Operation(summary = "알림 삭제", description = "사용자가 알림을 삭제합니다.")
     @Parameter(name = "notification_id", description = "삭제할 알림의 고유 ID", example = "1")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -22,7 +22,7 @@ public interface NotificationControllerDocs {
             @AuthenticationPrincipal Long memberId
     );
 
-    @Operation(summary = "미수신 알림 내역 조회 (Inbox)", description = "사용자에게 도착한 알림 중 아직 읽지 않은(삭제되지 않은) 내역을 조회합니다.")
+    @Operation(summary = "알림 내역 조회", description = "모든 알림을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
@@ -31,8 +31,23 @@ public interface NotificationControllerDocs {
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") Integer size
     );
+    @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    whoreads.backend.global.response.ApiResponse<NotificationResDTO.HistoryDTO> readNotification(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable(value = "notification_id") Long notificationId
+    );
+    @Operation(summary = "모든 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    whoreads.backend.global.response.ApiResponse<Void> readAllNotifications(
+            @AuthenticationPrincipal Long memberId
+    );
 
-    @Operation(summary = "알림 읽음 처리 (내역 삭제)", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
+    @Operation(summary = "알림 삭제", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
     @Parameter(name = "notification_id", description = "삭제할 알림의 고유 ID", example = "1")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/src/main/java/whoreads/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/whoreads/backend/domain/notification/converter/NotificationConverter.java
@@ -1,12 +1,13 @@
 package whoreads.backend.domain.notification.converter;
 
 import whoreads.backend.domain.notification.dto.NotificationResDTO;
+import whoreads.backend.domain.notification.entity.FollowLink;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 import whoreads.backend.domain.notification.entity.NotificationSetting;
 import whoreads.backend.domain.notification.enums.NotificationType;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 public class NotificationConverter {
 
@@ -47,8 +48,14 @@ public class NotificationConverter {
                 .title(history.getTitle())
                 .body(history.getBody())
                 .type(history.getType().name())
+                .isRead(history.isRead())
                 .createdAt(history.getCreatedAt())
-                .link(history.getLink())
+                .link(Optional.ofNullable(history.getLink())
+                        .map(link -> FollowLink.builder()
+                                .celebrityId(link.getCelebrityId())
+                                .bookId(link.getBookId())
+                                .build())
+                        .orElse(null))
                 .build();
     }
 

--- a/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import whoreads.backend.domain.notification.entity.FollowLink;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -46,7 +47,8 @@ public class NotificationResDTO {
             String type,
             String title,
             String body,
-            String link,
+            FollowLink link,
+            boolean isRead,
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ){}

--- a/src/main/java/whoreads/backend/domain/notification/entity/FollowLink.java
+++ b/src/main/java/whoreads/backend/domain/notification/entity/FollowLink.java
@@ -1,0 +1,14 @@
+package whoreads.backend.domain.notification.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowLink {
+    private Long bookId;
+    private Long celebrityId;
+}

--- a/src/main/java/whoreads/backend/domain/notification/entity/NotificationHistory.java
+++ b/src/main/java/whoreads/backend/domain/notification/entity/NotificationHistory.java
@@ -30,6 +30,14 @@ public class NotificationHistory extends BaseEntity {
     @Column(nullable = false)
     private String body;
 
-    @Column()
-    private String link;
+    @Embedded
+    private FollowLink link;
+    
+    @Builder.Default
+    private boolean isRead = false;
+
+    public void setRead()
+    {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/whoreads/backend/domain/notification/enums/NotificationMessageType.java
+++ b/src/main/java/whoreads/backend/domain/notification/enums/NotificationMessageType.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationMessageType {
-    NEW_FOLLOW_BOOK("%s의 서재에 새 책이 추가됐어요!", "『%s』 %s") {
+    NEW_FOLLOW_BOOK("[%s]의 서재에 새 책이 추가됐어요!", "[%s-%s]") {
         @Override
         public String[] generate(NotificationEvent event) {
             if (event instanceof NotificationEvent.FollowEvent e) {

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -22,7 +22,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomaticall=true,clearAutomatically = true)
     @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
     void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -2,6 +2,7 @@ package whoreads.backend.domain.notification.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 
@@ -20,4 +21,8 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             Pageable pageable);
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
+    void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -22,7 +22,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
 
-    @Modifying(flushAutomaticall=true,clearAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
     void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
@@ -5,6 +5,8 @@ import whoreads.backend.domain.notification.dto.NotificationResDTO;
 
 public interface NotificationHistoryService {
    NotificationResDTO.TotalInboxDTO getNotificationHistory(Long memberId, Long cursor, int size);
-   void readNotification(Long memberId, Long notificationId);
+   NotificationResDTO.HistoryDTO readNotification(Long memberId, Long notificationId);
+   Void readAllNotifications(Long memberId);
    void saveHistory(Long memberId, FcmMessageDTO dto);
+   void deleteNotification(Long memberId,Long notificationId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
@@ -9,6 +9,7 @@ import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.domain.notification.converter.NotificationConverter;
 import whoreads.backend.domain.notification.dto.FcmMessageDTO;
 import whoreads.backend.domain.notification.dto.NotificationResDTO;
+import whoreads.backend.domain.notification.entity.FollowLink;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 import whoreads.backend.domain.notification.enums.NotificationType;
 import whoreads.backend.domain.notification.repository.NotificationHistoryRepository;
@@ -38,14 +39,34 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
 
     @Override
     @Transactional
-    public void readNotification(Long memberId, Long notificationId) {
+    public NotificationResDTO.HistoryDTO readNotification(Long memberId, Long notificationId) {
         // 이 알림의 권한이 사용자인지 확인
+        NotificationHistory history = notificationHistoryRepository.findById(notificationId).orElseThrow(()->
+                new CustomException(ErrorCode.RESOURCE_NOT_FOUND,"알림이 존재하지 않습니다."));
+        if (!Objects.equals(history.getMember().getId(), memberId))
+            throw new CustomException(ErrorCode.ACCESS_DENIED,"사용자의 알림이 아닙니다.");
+        history.setRead();
+        notificationHistoryRepository.save(history);
+        return NotificationConverter.toHistoryDTO(history);
+    }
+
+    @Transactional
+    @Override
+    public void deleteNotification(Long memberId,Long notificationId) {
         NotificationHistory history = notificationHistoryRepository.findById(notificationId).orElseThrow(()->
                 new CustomException(ErrorCode.RESOURCE_NOT_FOUND,"알림이 존재하지 않습니다."));
         if (!Objects.equals(history.getMember().getId(), memberId))
             throw new CustomException(ErrorCode.ACCESS_DENIED,"사용자의 알림이 아닙니다.");
         notificationHistoryRepository.delete(history);
     }
+
+    @Transactional
+    @Override
+    public Void readAllNotifications(Long memberId) {
+        notificationHistoryRepository.setReadAllNotifications(memberId);
+        return null;
+    }
+
     @Transactional
     public void saveHistory(Long memberId, FcmMessageDTO dto) {
         NotificationHistory history = NotificationHistory.builder()
@@ -53,6 +74,7 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
                 .title(dto.getTitle())
                 .body(dto.getBody())
                 .type(NotificationType.valueOf(dto.getType()))
+                .link(FollowLink.builder().celebrityId(dto.getCelebrityId()).bookId(dto.getBookId()).build())
                 .build();
         notificationHistoryRepository.save(history);
     }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -57,11 +57,13 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                         .setTitle(dto.getTitle())
                         .setBody(dto.getBody())
                         .build())
-                // ios 전용 설정 ( 알림 클릭 시 동작 및 소리 )
-                .setApnsConfig(ApnsConfig.builder()
-                        .setAps(Aps.builder()
-                                .setCategory("CLICK_ACTION")
-                                .setSound("default")
+                // 안드로이드 설정 추가
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH) // 즉시 발송
+                        .setNotification(AndroidNotification.builder()
+                                .setChannelId("high_importance_channel") // 프런트와 일치 필수
+                                .setIcon("app_logo") // 💡 사진에 올린 파일명 (확장자 제외)
+                                .setClickAction("FLUTTER_NOTIFICATION_CLICK") // 백그라운드 클릭 핸들링용
                                 .build())
                         .build())
                 // 커스텀 데이터 ( 프론트 확인용 )
@@ -86,6 +88,14 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                     .setNotification(Notification.builder()
                             .setTitle(dto.getTitle())
                             .setBody(dto.getBody())
+                            .build())
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setPriority(AndroidConfig.Priority.HIGH)
+                            .setNotification(AndroidNotification.builder()
+                                    .setChannelId("high_importance_channel")
+                                    .setIcon("app_logo") // 💡 파일명 매칭
+                                    .setClickAction("FLUTTER_NOTIFICATION_CLICK")
+                                    .build())
                             .build())
                     .putData("title", dto.getTitle())
                     .putData("body", dto.getBody())

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -87,13 +87,6 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                             .setTitle(dto.getTitle())
                             .setBody(dto.getBody())
                             .build())
-                    // ios 전용 설정 ( 알림 클릭 시 동작 및 소리 )
-                    .setApnsConfig(ApnsConfig.builder()
-                            .setAps(Aps.builder()
-                                    .setCategory("CLICK_ACTION")
-                                    .setSound("default")
-                                    .build())
-                            .build())
                     .putData("title", dto.getTitle())
                     .putData("body", dto.getBody())
                     .putData("type", dto.getType());

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationScheduler.java
@@ -53,7 +53,7 @@ public class NotificationScheduler {
     @Transactional
     @Scheduled(cron = "0 0 0 * * *",zone = "Asia/Seoul") // 매일 자정 실행
     public void deleteOldNotifications() {
-        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
         notificationHistoryRepository.deleteByCreatedAtBefore(cutoff);
     }
     /*


### PR DESCRIPTION
## 📝 작업 요약
- 알림 정책 변경

## 🛠 주요 변경 사항
- [x] 알림 읽음 처리, 삭제 분리
- [x] 미수신 알림 삭제 30-> 7일

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 알림 기능 개선 사항

* **새로운 기능**
  * 개별 알림을 읽음으로 표시하는 기능 추가
  * 모든 알림을 한 번에 읽음 처리하는 기능 추가

* **개선**
  * 알림의 읽음/미읽음 상태가 화면에 표시되도록 반영
  * 알림 삭제/읽음 처리 동작을 명확히 분리
  * 알림 링크 구조 정형화로 관련 콘텐츠로 안전하게 연결
  * 푸시 전송 설정을 단순화해 Android 전달 신뢰성 향상
  * 알림 보관 기간 단축 (30일 → 7일)
  * 특정 알림 유형의 제목/본문 템플릿 문구 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->