### PR TITLE
[Feat] ReadingSession heartbeat API 및 stale 세션 자동 완료 처리 추가

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   db:
     image: mysql:8.0
-    container_name: whoreads-local-db
+    container_name: local-db
     ports:
       - "3306:3306"
     environment:
@@ -13,8 +13,8 @@ services:
       - --character-set-server=utf8mb4
       - --collation-server=utf8mb4_unicode_ci
     volumes:
-      # 1. 데이터 저장소 (로컬에 저장해서 껐다 켜도 데이터 유지)
-      - ./db/data:/var/lib/mysql
+      # 1. 데이터 저장소 (Docker named volume으로 관리, 프로젝트 무관하게 유지)
+      - local-db-data:/var/lib/mysql
       # 2. [핵심] 초기화 스크립트 자동 실행 폴더 연결
       - ./db/initdb:/docker-entrypoint-initdb.d
     healthcheck:
@@ -23,3 +23,6 @@ services:
       timeout: 5s
       retries: 5
     restart: always
+
+volumes:
+  local-db-data:

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
@@ -71,7 +71,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.heartbeat(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("세션 heartbeat 정보를 전송했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("세션 heartbeat 정보를 전송했습니다.").withServerTime());
     }
 
     private void validateAuthentication(Long memberId) {

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
@@ -63,6 +63,17 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
         return ResponseEntity.ok(ApiResponse.success("독서 세션을 완료했습니다."));
     }
 
+    @Override
+    @PatchMapping("/{sessionId}/heartbeat")
+    public ResponseEntity<ApiResponse<Void>> heartbeat(
+            @PathVariable Long sessionId,
+            @AuthenticationPrincipal Long memberId
+    ) {
+        validateAuthentication(memberId);
+        readingSessionService.heartbeat(sessionId, memberId);
+        return ResponseEntity.ok(ApiResponse.success("세션 heartbeat 정보를 전송했습니다."));
+    }
+
     private void validateAuthentication(Long memberId) {
         if (memberId == null) {
             throw new CustomException(ErrorCode.UNAUTHORIZED);

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionControllerDocs.java
@@ -203,4 +203,30 @@ public interface ReadingSessionControllerDocs {
             Long sessionId,
             @AuthenticationPrincipal Long memberId
     );
+
+    @Operation(
+            summary = "독서 세션 heartbeat",
+            description = "앱이 살아있음을 서버에 알립니다. 5분마다 호출하세요. 일정 시간 heartbeat가 없으면 서버가 세션을 자동 완료 처리합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "heartbeat 갱신 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "세션 heartbeat 정보를 전송했습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponse<Void>> heartbeat(
+            @Parameter(description = "세션 ID", required = true)
+            Long sessionId,
+            @AuthenticationPrincipal Long memberId
+    );
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
@@ -37,6 +37,9 @@ public class ReadingSession extends BaseEntity {
     @Column(name = "finished_at")
     private LocalDateTime finishedAt;
 
+    @Column(name = "last_heartbeat_at")
+    private LocalDateTime lastHeartbeatAt;
+
     @OneToMany(mappedBy = "readingSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReadingInterval> intervals = new ArrayList<>();
 
@@ -59,6 +62,10 @@ public class ReadingSession extends BaseEntity {
             throw new IllegalStateException("일시정지된 세션만 재개할 수 있습니다. 현재 상태: " + this.status);
         }
         this.status = SessionStatus.IN_PROGRESS;
+    }
+
+    public void heartbeat() {
+        this.lastHeartbeatAt = LocalDateTime.now();
     }
 
     public void complete() {

--- a/src/main/java/whoreads/backend/domain/readingsession/repository/ReadingSessionRepository.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/repository/ReadingSessionRepository.java
@@ -34,4 +34,8 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSession, 
             @Param("memberId") Long memberId,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end);
+
+    @Query("SELECT rs FROM ReadingSession rs JOIN FETCH rs.intervals " +
+            "WHERE rs.status = 'IN_PROGRESS' AND rs.lastHeartbeatAt < :threshold")
+    List<ReadingSession> findStaleInProgressSessions(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionScheduler.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionScheduler.java
@@ -1,0 +1,41 @@
+package whoreads.backend.domain.readingsession.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whoreads.backend.domain.readingsession.entity.ReadingSession;
+import whoreads.backend.domain.readingsession.repository.ReadingSessionRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReadingSessionScheduler {
+
+    private final ReadingSessionRepository readingSessionRepository;
+
+    @Transactional
+    @Scheduled(fixedDelay = 60_000, zone = "Asia/Seoul")
+    public void expireStaleSessions() {
+        LocalDateTime threshold = LocalDateTime.now().minusHours(5);
+        List<ReadingSession> staleSessions = readingSessionRepository.findStaleInProgressSessions(threshold);
+
+        if (staleSessions.isEmpty()) {
+            return;
+        }
+
+        for (ReadingSession session : staleSessions) {
+            session.getIntervals().stream()
+                    .filter(interval -> interval.getEndTime() == null)
+                    .findFirst()
+                    .ifPresent(interval -> interval.end(session.getLastHeartbeatAt()));
+            session.complete();
+        }
+
+        log.info("[ReadingSessionScheduler] stale 세션 {}건 자동 완료 처리", staleSessions.size());
+    }
+}

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionService.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionService.java
@@ -11,4 +11,6 @@ public interface ReadingSessionService {
     void resumeSession(Long sessionId, Long memberId);
 
     void completeSession(Long sessionId, Long memberId);
+
+    void heartbeat(Long sessionId, Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
@@ -90,6 +90,12 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
         session.complete();
     }
 
+    @Override
+    public void heartbeat(Long sessionId, Long memberId) {
+        ReadingSession session = findByIdAndValidateOwnership(sessionId, memberId);
+        session.heartbeat();
+    }
+
     private ReadingSession findByIdAndValidateOwnership(Long sessionId, Long memberId) {
         ReadingSession session = readingSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SESSION_NOT_FOUND));


### PR DESCRIPTION
## 📝 작업 요약
- 앱 강제 종료 시 서버가 세션 상태를 감지할 수 있도록 heartbeat 메커니즘 추가

## 🔗 관련 이슈(있으면)
- #133

## 🛠 주요 변경 사항
- [x] `PATCH /api/reading-sessions/{id}/heartbeat` 엔드포인트 추가
- [x] `ReadingSession` 엔티티에 `lastHeartbeatAt` 필드 추가
- [x] `ReadingSessionScheduler` 추가 - 마지막 heartbeat로부터 5시간 경과 시 세션 자동 완료 처리 (1분 주기)

## 🔍 리뷰 포인트
- **로직**: stale 세션 자동 완료 시 마지막 `lastHeartbeatAt` 기준으로 열린 interval을 닫고 `complete()` 처리합니다.
- **성능**: `findStaleInProgressSessions`에서 intervals를 fetch join으로 함께 조회해 N+1 방지했습니다.
- **보안**: heartbeat 호출 시 세션 소유자 검증을 수행합니다.

## 📸 테스트 결과 (선택 사항)
N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 세션 heartbeat API 제공: 읽기 세션을 활성 상태로 유지하기 위해 클라이언트가 주기적으로 heartbeat 신호를 전송할 수 있습니다(성공 시 200 응답).
  * 비활성 세션 자동 만료: 5시간 이상 활동이 없는 진행 중인 세션은 서버가 자동으로 종료하고 완료 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->