### PR TITLE
[Feat] ReadingSession API 응답에 서울 기준 서버 시간 필드 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
@@ -27,7 +27,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
         validateAuthentication(memberId);
         ReadingSessionResponse.StartResult result = readingSessionService.startSession(memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created("독서 세션을 시작했습니다.", result));
+                .body(ApiResponse.created("독서 세션을 시작했습니다.", result).withServerTime());
     }
 
     @Override
@@ -38,7 +38,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.pauseSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 일시정지했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 일시정지했습니다.").withServerTime());
     }
 
     @Override
@@ -49,7 +49,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.resumeSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 재개했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 재개했습니다.").withServerTime());
     }
 
     @Override
@@ -60,7 +60,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.completeSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 완료했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 완료했습니다.").withServerTime());
     }
 
     private void validateAuthentication(Long memberId) {

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -26,8 +26,8 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
-    `@JsonProperty`("server_time")
-    `@JsonFormat`(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
+    @JsonProperty("server_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
     private final ZonedDateTime serverTime;
 
     @JsonProperty("result")

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -26,8 +26,8 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
-    @JsonProperty("server_time")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    `@JsonProperty`("server_time")
+    `@JsonFormat`(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
     private final ZonedDateTime serverTime;
 
     @JsonProperty("result")

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -1,15 +1,19 @@
 package whoreads.backend.global.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 
 @Getter
 @Builder
-@JsonPropertyOrder({"is_success", "code", "message", "result"})
+@JsonPropertyOrder({"is_success", "code", "message", "server_time", "result"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
@@ -22,8 +26,22 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
+    @JsonProperty("server_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final ZonedDateTime serverTime;
+
     @JsonProperty("result")
     private final T result;
+
+    public ApiResponse<T> withServerTime() {
+        return ApiResponse.<T>builder()
+                .isSuccess(this.isSuccess)
+                .code(this.code)
+                .message(this.message)
+                .serverTime(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
+                .result(this.result)
+                .build();
+    }
 
     public static <T> ApiResponse<T> success(T result) {
         return ApiResponse.<T>builder()


### PR DESCRIPTION
## 📝 작업 요약
- 클라이언트 타이머 동기화를 위해 ReadingSession API 응답에 서버 현재 시간(서울 기준) 필드 추가

## 🔗 관련 이슈(있으면)
- #134

## 🛠 주요 변경 사항
- [x] `ApiResponse`에 `server_time` 필드 추가 (Asia/Seoul, `@JsonInclude(NON_NULL)`)
- [x] `withServerTime()` 메서드로 필요한 API에만 선택적 적용
- [x] start / pause / resume / complete 응답에 적용

## 🔍 리뷰 포인트
- **로직**: `server_time`은 `NON_NULL` 직렬화로 설정하지 않은 API 응답에는 필드가 노출되지 않습니다.
- **보안**: N/A

## 📸 테스트 결과 (선택 사항)
N/A

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 읽기 세션 관련 API(시작·일시정지·재개·완료) 응답 본문에 서버 현재 시간이 추가되었습니다.
  * 응답의 타임스탬프는 서울(Asia/Seoul) 기준 형식으로 포함되어 결과 앞에 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->