### PR TITLE
chore: Spring Boot 4.0.5, springdoc 3.0.2로 의존성 업그레이드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,10 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // Swagger (SpringDoc OpenAPI)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 
     // Health Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -40,10 +40,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Test DB
@@ -60,6 +58,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Mac M3
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64'
 }
 
 tasks.named('test') {


### PR DESCRIPTION
## 📝 작업 요약
Spring Boot 4.x 호환 버전으로 의존성 업그레이드합니다.

## 🔗 관련 이슈
- closes #143

## 🛠 주요 변경 사항
- [x] Spring Boot 4.0.1 → 4.0.5
- [x] springdoc-openapi 2.8.4 → 3.0.2 (Spring Boot 4.x 전용 버전)
- [x] `spring-boot-starter-webmvc` → `spring-boot-starter-web` (Jackson 자동설정 포함)
- [x] 테스트 의존성 정리 (`starter-test`로 통합)

## 🔍 리뷰 포인트
- **근본 원인**: springdoc 2.x(Boot 3.x용)를 Boot 4에서 사용하면 Jackson 3.x auto-configuration이 동작하지 않아 `SecurityErrorHandler`의 `ObjectMapper` bean 주입 실패
- **해결**: springdoc 3.x는 Jackson 3.x auto-configuration을 올바르게 지원 → `ObjectMapper` bean 정상 주입

## 📸 테스트 결과
- `BackendApplicationTests.contextLoads()` ✅ PASSED
- 전체 테스트 ✅ BUILD SUCCESSFUL

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? — N/A