### PR TITLE
fix: 배포 스크립트 인프라 컨테이너 충돌 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,15 +137,9 @@ jobs:
               fi
             fi
 
-            # Redis, Nginx 컨테이너 확인 및 기동
-            # 실행 중이지 않은 동일 이름 컨테이너(compose 외부 생성 포함)를 정리 후 기동
-            for container in whoreads-redis whoreads-nginx; do
-              if docker ps --format "{{.Names}}" | grep -q "^${container}$"; then
-                echo "$container is already running, skipping"
-              else
-                docker rm -f "$container" 2>/dev/null || true
-              fi
-            done
+            # Redis, Nginx 컨테이너 정리 후 기동 (Exited 상태 포함 모든 충돌 컨테이너 제거)
+            echo "Cleaning up infra containers..."
+            docker rm -f whoreads-redis whoreads-nginx 2>/dev/null || true
             docker compose up -d whoreads-redis whoreads-nginx
 
             # ========================================


### PR DESCRIPTION
## 📝 작업 요약
- 배포 시 Redis/Nginx 컨테이너 이름 충돌로 `docker compose up` 실패하는 문제 수정

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] `deploy.yml` Step 1: `docker ps` 기반 조건부 체크 로직 제거, `docker rm -f`로 무조건 선처리 후 기동

## 🔍 리뷰 포인트
- `docker ps`는 실행 중인 컨테이너만 조회하므로 **Exited 상태** 컨테이너를 감지하지 못함
- 기존 로직은 Exited 컨테이너가 있을 때 `docker rm -f`를 시도하나, 이후 `docker compose up`이 동일 이름 컨테이너와 충돌
- `docker rm -f ... 2>/dev/null || true`로 상태에 관계없이 제거 후 compose로 재기동하면 충돌 원천 차단

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가? (해당 없음)

## 🛠 Troubleshooting
### 1. 문제 현상
- `docker compose up -d whoreads-redis whoreads-nginx` 실행 시 컨테이너 이름 Conflict 에러

### 2. 원인 분석
- `docker ps`는 Running 상태만 반환 → Exited 컨테이너를 "없음"으로 판단
- else 분기의 `docker rm -f`가 실패하거나 타이밍 문제로 compose가 기존 컨테이너와 충돌

### 3. 해결 방안
- 조건문 제거, `docker rm -f whoreads-redis whoreads-nginx 2>/dev/null || true`로 상태 무관하게 선처리