### PR TITLE
fix: 배포 인프라 컨테이너 충돌 및 SSL 인증서 마운트 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
       - ./nginx/certs:/etc/nginx/certs:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     networks:
       - whoreads-network
 


### PR DESCRIPTION
## 📝 작업 요약
- 배포 스크립트에서 Exited 상태의 인프라 컨테이너(redis, nginx)와의 이름 충돌로 배포 실패하는 문제 수정
- nginx 컨테이너에 `/etc/letsencrypt` 볼륨 마운트 누락으로 `nginx -t` 검증 실패하는 문제 수정

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] 외부 API 또는 인프라(S3, FCM 등) 연동 설정

## 🔍 리뷰 포인트
- **로직**: 인프라 컨테이너를 매 배포 시 강제 삭제(`docker rm -f`) 후 재시작하는 방식이 적절한지 확인
- **보안**: `/etc/letsencrypt`를 read-only로 마운트하여 인증서 파일 보호

## 📸 테스트 결과 (선택 사항)
- EC2에서 Let's Encrypt 인증서 발급 후 배포 파이프라인 정상 동작 확인 예정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? (N/A)

## 🛠 Troubleshooting
### 1. 문제 현상
- `Current active: none` (최초 배포 또는 컨테이너 없는 상태)에서 배포 시 `nginx -t` 실패 → rollback → 배포 실패

### 2. 원인 분석
- **인프라 충돌**: 이전에 수동으로 생성된 컨테이너가 Exited 상태로 남아있을 때, `docker compose up`이 이름 충돌로 실패
- **SSL 인증서 미마운트**: `default.conf.template`은 `/etc/letsencrypt/live/.../fullchain.pem`을 참조하지만, `docker-compose.yml`에 해당 경로 볼륨 마운트가 없어 nginx 컨테이너 내부에서 파일을 찾지 못함 → `nginx -t` 실패

### 3. 해결 방안
- 배포 시 인프라 컨테이너를 `docker rm -f`로 강제 정리 후 재시작
- `docker-compose.yml`의 nginx 서비스에 `/etc/letsencrypt:/etc/letsencrypt:ro` 볼륨 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Nginx 서비스의 저장소 구성을 업데이트하여 추가 인증서 경로를 마운트하도록 변경했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->