### PR TITLE
fix: nginx 재시작 루프 긴급 수정 (Docker DNS resolver)

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -41,9 +41,11 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
 
-    # Proxy to Production (Blue/Green)
+    # Proxy to Production (Blue/Green) - Docker DNS로 런타임 resolve
     location / {
-        proxy_pass http://whoreads-prod-blue:8080;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream whoreads-prod-blue;
+        proxy_pass http://$upstream:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -64,9 +66,11 @@ server {
     listen 80 default_server;
     server_name _;  # 모든 호스트명 (IP 직접 접근 포함)
 
-    # Proxy to Staging (Blue/Green)
+    # Proxy to Staging (Blue/Green) - Docker DNS로 런타임 resolve
     location / {
-        proxy_pass http://whoreads-staging-blue:8080;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream whoreads-staging-blue;
+        proxy_pass http://$upstream:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## 📝 작업 요약
- nginx가 `whoreads-prod-blue` 컨테이너 미존재 시 시작 시점에 'host not found' 에러로 재시작 루프에 빠지는 문제 긴급 수정

## 🔗 관련 이슈(있으면)
- N/A (긴급 핫픽스)

## 🛠 주요 변경 사항
- [x] `nginx/default.conf.template`: `proxy_pass` 직접 호스트명 → `resolver 127.0.0.11` + `set $upstream` 변수 방식으로 변경

## 🔍 리뷰 포인트
- `resolver 127.0.0.11`은 Docker 내장 DNS로, 컨테이너 네트워크 내 hostname을 런타임에 resolve
- `proxy_pass` 변수 사용 시 nginx가 시작 시점이 아닌 요청 시점에 DNS 조회하므로 컨테이너 미존재 상태에서도 nginx 정상 기동

## 🛠 Troubleshooting
### 1. 문제 현상
- nginx 컨테이너 재시작 루프: `host not found in upstream "whoreads-prod-blue"`

### 2. 원인 분석
- `proxy_pass http://whoreads-prod-blue:8080` 직접 사용 시 nginx가 시작 시 DNS resolve 시도
- staging 서버에 `whoreads-prod-blue` 컨테이너가 없어 resolve 실패 → nginx exit → restart loop

### 3. 해결 방안
- `resolver 127.0.0.11 valid=30s` + `set $upstream` 변수로 런타임 resolve 방식 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 업스트림 프록시 설정을 개선하여 런타임 DNS 해석 기능을 적용했습니다. 이를 통해 동적 배포 환경에서의 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->