### PR TITLE
fix: CD prod secrets → vars 참조 오류 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
@@ -52,8 +52,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -93,7 +93,7 @@ jobs:
             NETWORK_NAME="whoreads-network"
             NGINX_CONTAINER="whoreads-nginx"
             NGINX_CONF="$DEPLOY_DIR/nginx/conf.d/default.conf"
-            DOCKER_IMAGE="${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}"
+            DOCKER_IMAGE="${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}"
             CONTAINER_PREFIX="whoreads-${ENVIRONMENT}"
 
             # ========================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Copy Nginx template to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "nginx/default.conf.template"
           target: "~/whoreads/"
@@ -79,8 +79,8 @@ jobs:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             set -e
@@ -172,10 +172,10 @@ jobs:
               --name "${CONTAINER_PREFIX}-$NEW" \
               --network "$NETWORK_NAME" \
               -e SPRING_PROFILES_ACTIVE=${{ inputs.spring_profile }} \
-              -e DB_HOST="${{ secrets.RDS_HOST }}" \
-              -e DB_PORT="${{ secrets.DB_PORT }}" \
-              -e DB_NAME="${{ secrets.DB_NAME }}" \
-              -e DB_USERNAME="${{ secrets.DB_USER }}" \
+              -e DB_HOST="${{ vars.DB_HOST }}" \
+              -e DB_PORT="${{ vars.DB_PORT }}" \
+              -e DB_NAME="${{ vars.DB_NAME }}" \
+              -e DB_USERNAME="${{ vars.DB_USER }}" \
               -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
               -e REDIS_HOST="whoreads-redis" \
               -e MAIL_ID="${{ secrets.MAIL_ID }}" \


### PR DESCRIPTION
## 📝 작업 요약
- CD Production 워크플로우에서 Docker 로그인 실패 및 EC2/DB 접속 실패 원인 수정
- `deploy.yml`에서 repository variable로 등록된 값들이 `secrets.`로 잘못 참조되던 문제 해결

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] `secrets.DOCKER_USERNAME` → `vars.DOCKER_USERNAME`
- [x] `secrets.EC2_HOST` → `vars.EC2_HOST`
- [x] `secrets.EC2_USER` → `vars.EC2_USER`
- [x] `secrets.RDS_HOST` → `vars.DB_HOST`
- [x] `secrets.DB_PORT` → `vars.DB_PORT`
- [x] `secrets.DB_NAME` → `vars.DB_NAME`
- [x] `secrets.DB_USER` → `vars.DB_USER`

## 🔍 리뷰 포인트
- develop 브랜치 `deploy.yml`은 이미 `vars.`를 사용 중 → staging 배포 정상 동작
- main 브랜치만 오래된 버전으로 `secrets.`를 사용하고 있어 prod 배포 시 "Username required" 에러 발생
- 패스워드·SSH 키·API 키 등 실제 민감 정보는 그대로 `secrets.` 유지

## 📸 테스트 결과 (선택 사항)
- CD Staging(develop 브랜치)에서 동일 구조로 정상 배포 확인됨

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? (해당 없음)

## 🛠 Troubleshooting
### 1. 문제 현상
- CD Production 워크플로우 실행 시 Docker Hub 로그인 단계에서 `Username required` 에러 발생

### 2. 원인 분석
- `DOCKER_USERNAME`은 GitHub repository variable(`vars.`)로 등록되어 있으나, main 브랜치의 `deploy.yml`에서 `secrets.DOCKER_USERNAME`으로 참조
- `secrets.`로 접근 시 값이 비어있어 username이 전달되지 않음
- develop 브랜치는 이미 `vars.`로 수정되어 있어 staging은 정상, prod만 실패

### 3. 해결 방안
- `deploy.yml`에서 민감하지 않은 설정값(hostname, username, DB 접속 정보 등) 모두 `vars.`로 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 배포 워크플로우 구성을 업데이트했습니다. Docker 이미지 네임스페이스, EC2 호스트 정보, 데이터베이스 연결 설정 등이 GitHub 저장소 변수로 이전되었습니다. 보안 관련 값(암호, API 키 등)은 기존 보안 저장소에서 관리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->