### PR TITLE
chore: develop → main 동기화 (CI/CD, 의존성, 버그 수정)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,13 +34,6 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Setup Firebase secret key
-        run: |
-          mkdir -p ./src/main/resources/firebase
-          echo "$FIREBASE_SECRET_JSON_BASE64" | base64 -d > ./src/main/resources/firebase/secret-key.json
-        env:
-          FIREBASE_SECRET_JSON_BASE64: ${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}
-
       - name: Build with Gradle
         run: ./gradlew build -x test
 
@@ -92,7 +85,7 @@ jobs:
       - name: Deploy to EC2 (Blue/Green)
         uses: appleboy/ssh-action@v1.0.3
         env:
-          DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+          DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
           SPRING_PROFILE: ${{ inputs.spring_profile }}
           DB_HOST: ${{ vars.DB_HOST }}
           DB_PORT: ${{ vars.DB_PORT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,20 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Setup Firebase secret key
+        run: |
+          mkdir -p ./src/main/resources/firebase
+          echo "$FIREBASE_SECRET_JSON_BASE64" | base64 -d > ./src/main/resources/firebase/secret-key.json
+        env:
+          FIREBASE_SECRET_JSON_BASE64: ${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}
+
       - name: Build with Gradle
         run: ./gradlew build -x test
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -51,6 +63,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/arm64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
             ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
@@ -66,57 +79,63 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Copy Nginx template to EC2
+      - name: Copy files to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          source: "nginx/default.conf.template"
+          source: "docker-compose.yml,nginx/default.conf.template"
           target: "~/whoreads/"
           strip_components: 0
 
-      - name: Deploy to EC2
+      - name: Deploy to EC2 (Blue/Green)
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          DOCKER_IMAGE: ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+          SPRING_PROFILE: ${{ inputs.spring_profile }}
+          DB_HOST: ${{ secrets.RDS_HOST }}
+          DB_PORT: ${{ secrets.DB_PORT }}
+          DB_NAME: ${{ secrets.DB_NAME }}
+          DB_USERNAME: ${{ secrets.DB_USER }}
+          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MAIL_ID: ${{ secrets.MAIL_ID }}
+          MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
+          ALADIN_KEY: ${{ secrets.ALADIN_KEY }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          FIREBASE_SECRET_BASE64: ${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}
+          ENVIRONMENT: ${{ inputs.environment }}
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
+          envs: DOCKER_IMAGE,SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,MAIL_ID,MAIL_PASSWORD,ALADIN_KEY,JWT_SECRET,FIREBASE_SECRET_BASE64,ENVIRONMENT
           script: |
             set -e
 
             # ========================================
             # 변수 설정
             # ========================================
-            ENVIRONMENT="${{ inputs.environment }}"
             DEPLOY_DIR="$HOME/whoreads"
             NETWORK_NAME="whoreads-network"
             NGINX_CONTAINER="whoreads-nginx"
             NGINX_CONF="$DEPLOY_DIR/nginx/conf.d/default.conf"
-            DOCKER_IMAGE="${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}"
             CONTAINER_PREFIX="whoreads-${ENVIRONMENT}"
 
             # ========================================
-            # 1. 기초 공사: 디렉토리 및 네트워크 확인/생성
+            # 1. 기초 공사: 디렉토리 및 인프라 확인/생성
             # ========================================
             echo "=== Step 1: Infrastructure Setup ==="
 
-            # 배포 디렉토리 생성 (없으면)
-            if [ ! -d "$DEPLOY_DIR" ]; then
-              echo "Creating deploy directory: $DEPLOY_DIR"
-              mkdir -p "$DEPLOY_DIR"
-              mkdir -p "$DEPLOY_DIR/nginx/conf.d"
-            fi
+            mkdir -p "$DEPLOY_DIR/nginx/conf.d"
+            cd "$DEPLOY_DIR"
 
-            # Nginx 설정: 템플릿이 변경되었으면 복사
+            # Nginx 설정: 템플릿이 변경되었으면 반영
             NGINX_TEMPLATE="$DEPLOY_DIR/nginx/default.conf.template"
             TEMPLATE_HASH_FILE="$DEPLOY_DIR/nginx/.template_hash"
             if [ -f "$NGINX_TEMPLATE" ]; then
               NEW_HASH=$(md5sum "$NGINX_TEMPLATE" | cut -d' ' -f1)
-              OLD_HASH=""
-              if [ -f "$TEMPLATE_HASH_FILE" ]; then
-                OLD_HASH=$(cat "$TEMPLATE_HASH_FILE")
-              fi
+              OLD_HASH=$(cat "$TEMPLATE_HASH_FILE" 2>/dev/null || echo "")
               if [ ! -f "$NGINX_CONF" ] || [ "$NEW_HASH" != "$OLD_HASH" ]; then
                 echo "Updating nginx config from template..."
                 cp "$NGINX_TEMPLATE" "$NGINX_CONF"
@@ -124,15 +143,8 @@ jobs:
               fi
             fi
 
-            # Docker 네트워크 생성 (없으면)
-            if ! docker network inspect "$NETWORK_NAME" >/dev/null 2>&1; then
-              echo "Creating docker network: $NETWORK_NAME"
-              docker network create "$NETWORK_NAME"
-            else
-              echo "Docker network already exists: $NETWORK_NAME"
-            fi
-
-            cd "$DEPLOY_DIR"
+            # Redis, Nginx 컨테이너 확인 및 기동
+            docker compose up -d whoreads-redis whoreads-nginx
 
             # ========================================
             # 2. 현재 상태 확인 및 Blue/Green 결정
@@ -161,61 +173,51 @@ jobs:
             # ========================================
             echo "=== Step 4: Start New Container ==="
 
-            # 기존 동일 이름 컨테이너 정리
             docker stop "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
             docker rm "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
-
-            # Firebase Base64 키에서 줄바꿈 제거
-            FIREBASE_BASE64=$(echo "${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}" | tr -d '\n')
 
             docker run -d \
               --name "${CONTAINER_PREFIX}-$NEW" \
               --network "$NETWORK_NAME" \
-              -e SPRING_PROFILES_ACTIVE=${{ inputs.spring_profile }} \
-              -e DB_HOST="${{ secrets.RDS_HOST }}" \
-              -e DB_PORT="${{ secrets.DB_PORT }}" \
-              -e DB_NAME="${{ secrets.DB_NAME }}" \
-              -e DB_USERNAME="${{ secrets.DB_USER }}" \
-              -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
+              -e SPRING_PROFILES_ACTIVE="$SPRING_PROFILE" \
+              -e DB_HOST="$DB_HOST" \
+              -e DB_PORT="$DB_PORT" \
+              -e DB_NAME="$DB_NAME" \
+              -e DB_USERNAME="$DB_USERNAME" \
+              -e DB_PASSWORD="$DB_PASSWORD" \
               -e REDIS_HOST="whoreads-redis" \
-              -e MAIL_ID="${{ secrets.MAIL_ID }}" \
-              -e MAIL_PASSWORD="${{ secrets.MAIL_PASSWORD }}" \
-              -e ALADIN_KEY="${{ secrets.ALADIN_KEY }}" \
-              -e JWT_SECRET="${{ secrets.JWT_SECRET }}" \
-              -e FIREBASE_SECRET_BASE64="$FIREBASE_BASE64" \
+              -e REDIS_PORT="6379" \
+              -e MAIL_ID="$MAIL_ID" \
+              -e MAIL_PASSWORD="$MAIL_PASSWORD" \
+              -e ALADIN_KEY="$ALADIN_KEY" \
+              -e JWT_SECRET="$JWT_SECRET" \
+              -e FIREBASE_SECRET_BASE64="$FIREBASE_SECRET_BASE64" \
               "$DOCKER_IMAGE"
 
             # ========================================
             # 5. 헬스체크
             # ========================================
             echo "=== Step 5: Health Check ==="
-            echo "Waiting for application to start..."
             sleep 30
 
-            # 컨테이너 내부에서 헬스체크
             HEALTH=$(docker exec "${CONTAINER_PREFIX}-$NEW" curl -s http://localhost:8080/api/health)
 
             if echo "$HEALTH" | grep -q '"status"\s*:\s*"UP"'; then
-              echo "Health check passed! (Status is UP)"
+              echo "Health check passed!"
 
               # ========================================
-              # 6. Nginx 설정 변경 및 리로드 (Docker 방식)
+              # 6. Nginx 설정 변경 및 리로드
               # ========================================
-              echo "=== Step 6: Update Nginx Configuration ==="
+              echo "=== Step 6: Update Nginx ==="
 
-              # 롤백 함수 정의
               rollback_nginx() {
-                echo "Rolling back nginx config and cleaning up new container..."
-                if [ -f "$NGINX_CONF.bak" ]; then
-                  cp "$NGINX_CONF.bak" "$NGINX_CONF"
-                  echo "Restored nginx config from backup"
-                fi
+                echo "Rolling back nginx config..."
+                [ -f "$NGINX_CONF.bak" ] && cp "$NGINX_CONF.bak" "$NGINX_CONF"
                 docker stop "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
                 docker rm "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
                 exit 1
               }
 
-              # 6-1. Nginx 설정 파일 존재 확인 (필수)
               if [ ! -f "$NGINX_CONF" ]; then
                 echo "ERROR: Nginx config not found at $NGINX_CONF"
                 docker stop "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
@@ -223,49 +225,38 @@ jobs:
                 exit 1
               fi
 
-              # 6-2. Nginx 컨테이너 실행 확인 (필수)
               if ! docker ps --filter "name=$NGINX_CONTAINER" --format "{{.Names}}" | grep -q "$NGINX_CONTAINER"; then
-                echo "ERROR: Nginx container '$NGINX_CONTAINER' not found or not running"
+                echo "ERROR: Nginx container not running"
                 docker stop "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
                 docker rm "${CONTAINER_PREFIX}-$NEW" 2>/dev/null || true
                 exit 1
               fi
 
-              # 6-3. 현재 설정 백업
               cp "$NGINX_CONF" "$NGINX_CONF.bak"
-              echo "Backed up current nginx config"
-
-              # 6-4. sed 치환
               sed -i "s/${CONTAINER_PREFIX}-\(blue\|green\)/${CONTAINER_PREFIX}-$NEW/g" "$NGINX_CONF"
 
-              # 6-5. 변경 확인
               if ! grep -q "${CONTAINER_PREFIX}-$NEW" "$NGINX_CONF"; then
                 echo "ERROR: Failed to update Nginx config"
                 rollback_nginx
               fi
-              echo "Updated nginx config to point to: ${CONTAINER_PREFIX}-$NEW"
 
-              # 6-6. nginx -t 설정 문법 검사
               if ! docker exec "$NGINX_CONTAINER" nginx -t 2>&1; then
                 echo "ERROR: Nginx config validation failed"
                 rollback_nginx
               fi
-              echo "Nginx config validation passed"
 
-              # 6-7. nginx -s reload
               if ! docker exec "$NGINX_CONTAINER" nginx -s reload 2>&1; then
                 echo "ERROR: Nginx reload failed"
                 rollback_nginx
               fi
-              echo "Nginx reloaded successfully"
 
-              # 백업 파일 정리
               rm -f "$NGINX_CONF.bak"
+              echo "Nginx updated to: ${CONTAINER_PREFIX}-$NEW"
 
               # ========================================
               # 7. 이전 컨테이너 정리
               # ========================================
-              echo "=== Step 7: Cleanup Old Container ==="
+              echo "=== Step 7: Cleanup ==="
 
               if [ -n "$CURRENT" ]; then
                 docker stop "${CONTAINER_PREFIX}-$CURRENT" 2>/dev/null || true
@@ -273,11 +264,9 @@ jobs:
                 echo "Removed old container: ${CONTAINER_PREFIX}-$CURRENT"
               fi
 
-              # 사용하지 않는 이미지 정리
-              echo "Cleaning up unused images..."
               docker image prune -af --filter "until=24h" || true
-
               echo "=== Deployment Successful! ==="
+
             else
               echo "=== Health check FAILED! (Response: $HEALTH) Rolling back... ==="
               docker logs "${CONTAINER_PREFIX}-$NEW" --tail 50

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
@@ -65,8 +65,8 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -82,8 +82,8 @@ jobs:
       - name: Copy files to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "docker-compose.yml,nginx/default.conf.template"
           target: "~/whoreads/"
@@ -92,24 +92,25 @@ jobs:
       - name: Deploy to EC2 (Blue/Green)
         uses: appleboy/ssh-action@v1.0.3
         env:
-          DOCKER_IMAGE: ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+          DOCKER_IMAGE: ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
           SPRING_PROFILE: ${{ inputs.spring_profile }}
-          DB_HOST: ${{ secrets.RDS_HOST }}
-          DB_PORT: ${{ secrets.DB_PORT }}
-          DB_NAME: ${{ secrets.DB_NAME }}
-          DB_USERNAME: ${{ secrets.DB_USER }}
+          DB_HOST: ${{ vars.DB_HOST }}
+          DB_PORT: ${{ vars.DB_PORT }}
+          DB_NAME: ${{ vars.DB_NAME }}
+          DB_USERNAME: ${{ vars.DB_USER }}
           DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
           MAIL_ID: ${{ secrets.MAIL_ID }}
           MAIL_PASSWORD: ${{ secrets.MAIL_PASSWORD }}
           ALADIN_KEY: ${{ secrets.ALADIN_KEY }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           FIREBASE_SECRET_BASE64: ${{ secrets.FIREBASE_SECRET_JSON_BASE64 }}
+          REDIS_HOST: ${{ secrets.REDIS_HOST }}
           ENVIRONMENT: ${{ inputs.environment }}
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: DOCKER_IMAGE,SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,MAIL_ID,MAIL_PASSWORD,ALADIN_KEY,JWT_SECRET,FIREBASE_SECRET_BASE64,ENVIRONMENT
+          envs: DOCKER_IMAGE,SPRING_PROFILE,DB_HOST,DB_PORT,DB_NAME,DB_USERNAME,DB_PASSWORD,MAIL_ID,MAIL_PASSWORD,ALADIN_KEY,JWT_SECRET,FIREBASE_SECRET_BASE64,REDIS_HOST,ENVIRONMENT
           script: |
             set -e
 
@@ -185,7 +186,7 @@ jobs:
               -e DB_NAME="$DB_NAME" \
               -e DB_USERNAME="$DB_USERNAME" \
               -e DB_PASSWORD="$DB_PASSWORD" \
-              -e REDIS_HOST="whoreads-redis" \
+              -e REDIS_HOST="$REDIS_HOST" \
               -e REDIS_PORT="6379" \
               -e MAIL_ID="$MAIL_ID" \
               -e MAIL_PASSWORD="$MAIL_PASSWORD" \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,15 +137,9 @@ jobs:
               fi
             fi
 
-            # Redis, Nginx 컨테이너 확인 및 기동
-            # 실행 중이지 않은 동일 이름 컨테이너(compose 외부 생성 포함)를 정리 후 기동
-            for container in whoreads-redis whoreads-nginx; do
-              if docker ps --format "{{.Names}}" | grep -q "^${container}$"; then
-                echo "$container is already running, skipping"
-              else
-                docker rm -f "$container" 2>/dev/null || true
-              fi
-            done
+            # Redis, Nginx 컨테이너 정리 후 기동 (Exited 상태 포함 모든 충돌 컨테이너 제거)
+            echo "Cleaning up infra containers..."
+            docker rm -f whoreads-redis whoreads-nginx 2>/dev/null || true
             docker compose up -d whoreads-redis whoreads-nginx
 
             # ========================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,6 +138,14 @@ jobs:
             fi
 
             # Redis, Nginx 컨테이너 확인 및 기동
+            # 실행 중이지 않은 동일 이름 컨테이너(compose 외부 생성 포함)를 정리 후 기동
+            for container in whoreads-redis whoreads-nginx; do
+              if docker ps --format "{{.Names}}" | grep -q "^${container}$"; then
+                echo "$container is already running, skipping"
+              else
+                docker rm -f "$container" 2>/dev/null || true
+              fi
+            done
             docker compose up -d whoreads-redis whoreads-nginx
 
             # ========================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,7 +229,8 @@ jobs:
               fi
 
               cp "$NGINX_CONF" "$NGINX_CONF.bak"
-              sed -i "s/${CONTAINER_PREFIX}-\(blue\|green\)/${CONTAINER_PREFIX}-$NEW/g" "$NGINX_CONF"
+              sed -i "s/${CONTAINER_PREFIX}-blue/${CONTAINER_PREFIX}-$NEW/g" "$NGINX_CONF"
+              sed -i "s/${CONTAINER_PREFIX}-green/${CONTAINER_PREFIX}-$NEW/g" "$NGINX_CONF"
 
               if ! grep -q "${CONTAINER_PREFIX}-$NEW" "$NGINX_CONF"; then
                 echo "ERROR: Failed to update Nginx config"

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.1'
+    id 'org.springframework.boot' version '4.0.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -28,10 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // Swagger (SpringDoc OpenAPI)
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2'
 
     // Health Check
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -40,10 +40,8 @@ dependencies {
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-validation-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-security'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // Test DB
@@ -60,6 +58,9 @@ dependencies {
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // Mac M3
+    runtimeOnly 'io.netty:netty-resolver-dns-native-macos:4.1.104.Final:osx-aarch_64'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./nginx/conf.d:/etc/nginx/conf.d:ro
       - ./nginx/certs:/etc/nginx/certs:ro
     networks:
       - whoreads-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d:ro
       - ./nginx/certs:/etc/nginx/certs:ro
+      - /etc/letsencrypt:/etc/letsencrypt:ro
     networks:
       - whoreads-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  whoreads-redis:
+    image: redis:7-alpine
+    container_name: whoreads-redis
+    restart: always
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - whoreads-network
+
+  whoreads-nginx:
+    image: nginx:alpine
+    container_name: whoreads-nginx
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/conf.d:/etc/nginx/conf.d
+      - ./nginx/certs:/etc/nginx/certs:ro
+    networks:
+      - whoreads-network
+
+networks:
+  whoreads-network:
+    name: whoreads-network
+    driver: bridge

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -41,9 +41,11 @@ server {
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 1d;
 
-    # Proxy to Production (Blue/Green)
+    # Proxy to Production (Blue/Green) - Docker DNS로 런타임 resolve
     location / {
-        proxy_pass http://whoreads-prod-blue:8080;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream whoreads-prod-blue;
+        proxy_pass http://$upstream:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -64,9 +66,11 @@ server {
     listen 80 default_server;
     server_name _;  # 모든 호스트명 (IP 직접 접근 포함)
 
-    # Proxy to Staging (Blue/Green)
+    # Proxy to Staging (Blue/Green) - Docker DNS로 런타임 resolve
     location / {
-        proxy_pass http://whoreads-staging-blue:8080;
+        resolver 127.0.0.11 valid=30s;
+        set $upstream whoreads-staging-blue;
+        proxy_pass http://$upstream:8080;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
@@ -49,6 +49,12 @@ public interface BookControllerDocs {
     );
 
     @Operation(summary = "주제별 추천 책 목록 조회", description = "특정 주제(SOCIETY, HUMAN_UNDERSTANDING 등)에 맞는 유명인 추천 책 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "유효하지 않은 TopicTag 또는 limit 값", content = @Content),
+            @ApiResponse(responseCode = "404", description = "해당 주제의 책 없음", content = @Content),
+            @ApiResponse(responseCode = "500", description = "서버 오류", content = @Content)
+    })
     ResponseEntity<List<BookResponse>> getBooksByTheme(
             @Parameter(description = "주제 태그 (Enum 값)") @PathVariable TopicTag theme,
             @Parameter(description = "가져올 책 개수 (기본값 20)") @RequestParam(defaultValue = "20") int limit

--- a/src/main/java/whoreads/backend/domain/book/service/BookService.java
+++ b/src/main/java/whoreads/backend/domain/book/service/BookService.java
@@ -106,6 +106,10 @@ public class BookService {
 
     // 주제별 책 조회 로직
     public List<Book> getBooksByTheme(TopicTag theme, int limit) {
+        if (limit <= 0) {
+            throw new IllegalArgumentException("limit must be positive");
+        }
+
         // 프론트에서 TOP_20을 요청했을 땐 기존 로직 재사용
         if (theme == TopicTag.TOP_20) {
             return getMostRecommendedBooks(limit);

--- a/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
+++ b/src/main/java/whoreads/backend/domain/member/repository/MemberCelebrityRepository.java
@@ -25,7 +25,11 @@ public interface MemberCelebrityRepository extends JpaRepository<MemberCelebrity
 
     @Query("SELECT DISTINCT mc.member.id AS memberId, mc.member.fcmToken AS fcmToken " +
             "FROM MemberCelebrity mc " +
-            "WHERE mc.celebrity.id = :celebId " +
+            "JOIN mc.member m " +
+            "LEFT JOIN NotificationSetting ns ON ns.member = m " +
+            "AND ns.type = 'FOLLOW' " +
+            "Where mc.celebrity.id = :celebId " +
+            "AND (ns.id IS NULL OR ns.isEnabled = true) " +
             "AND mc.member.fcmToken IS NOT NULL " +
             "AND mc.member.fcmToken <> ''")
     List<MemberTokenDTO> findMemberTokensByCelebrityId(Long celebId);

--- a/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
@@ -55,7 +55,7 @@ public class NotificationController implements NotificationControllerDocs {
                 notificationHistoryService.readNotification(memberId,notificationId)
         );
     }
-    @PostMapping("/{notification_id}/read-all")
+    @PostMapping("/read-all")
     public ApiResponse<Void> readAllNotifications (
             @AuthenticationPrincipal Long memberId
     ){

--- a/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/NotificationController.java
@@ -33,8 +33,8 @@ public class NotificationController implements NotificationControllerDocs {
                 (fcmToken,FcmMessageDTO.of(NotificationType.ROUTINE,null));
         return ApiResponse.success("알림이 전송되었습니다.");
     }
-    // 미수신 알림 조회
-    @GetMapping("/inbox")
+    // 전체 알림 조회
+    @GetMapping()
     public ApiResponse<NotificationResDTO.TotalInboxDTO> getNotifications (
             @AuthenticationPrincipal Long memberId,
             @RequestParam(required = false) Long cursor,
@@ -45,13 +45,32 @@ public class NotificationController implements NotificationControllerDocs {
                 notificationHistoryService.getNotificationHistory(memberId,cursor,size)
        );
     }
-    // 알림 수신 처리 ( 삭제 )
-    @DeleteMapping("/inbox/{notification_id}")
+    @PatchMapping("/{notification_id}/read")
+    public ApiResponse<NotificationResDTO.HistoryDTO> readNotification (
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable(value = "notification_id") Long notificationId
+    ){
+        return ApiResponse.success(
+                "사용자의 알림을 읽음 처리 하였습니다.",
+                notificationHistoryService.readNotification(memberId,notificationId)
+        );
+    }
+    @PostMapping("/{notification_id}/read-all")
+    public ApiResponse<Void> readAllNotifications (
+            @AuthenticationPrincipal Long memberId
+    ){
+        return ApiResponse.success(
+                "사용자의 알림을 읽음 처리 하였습니다.",
+                notificationHistoryService.readAllNotifications(memberId)
+        );
+    }
+    // 알림 삭제 처리
+    @DeleteMapping("/{notification_id}")
     public ApiResponse<Void> deleteNotification(
             @AuthenticationPrincipal Long memberId,
             @PathVariable(value = "notification_id") Long notificationId
     ){
-        notificationHistoryService.readNotification(memberId,notificationId);
+        notificationHistoryService.deleteNotification(memberId,notificationId);
         return ApiResponse.success("알림을 성공적으로 삭제하였습니다.");
     }
 }

--- a/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -33,7 +33,7 @@ public interface NotificationControllerDocs {
     );
     @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
     })
     whoreads.backend.global.response.ApiResponse<NotificationResDTO.HistoryDTO> readNotification(
             @AuthenticationPrincipal Long memberId,
@@ -41,13 +41,13 @@ public interface NotificationControllerDocs {
     );
     @Operation(summary = "모든 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "조회 성공")
+            @ApiResponse(responseCode = "200", description = "읽음 처리 성공")
     })
     whoreads.backend.global.response.ApiResponse<Void> readAllNotifications(
             @AuthenticationPrincipal Long memberId
     );
 
-    @Operation(summary = "알림 삭제", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
+    @Operation(summary = "알림 삭제", description = "사용자가 알림을 삭제합니다.")
     @Parameter(name = "notification_id", description = "삭제할 알림의 고유 ID", example = "1")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/notification/controller/docs/NotificationControllerDocs.java
@@ -22,7 +22,7 @@ public interface NotificationControllerDocs {
             @AuthenticationPrincipal Long memberId
     );
 
-    @Operation(summary = "미수신 알림 내역 조회 (Inbox)", description = "사용자에게 도착한 알림 중 아직 읽지 않은(삭제되지 않은) 내역을 조회합니다.")
+    @Operation(summary = "알림 내역 조회", description = "모든 알림을 조회합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
@@ -31,8 +31,23 @@ public interface NotificationControllerDocs {
             @RequestParam(required = false) Long cursor,
             @RequestParam(defaultValue = "10") Integer size
     );
+    @Operation(summary = "알림 읽음 처리", description = "알림을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    whoreads.backend.global.response.ApiResponse<NotificationResDTO.HistoryDTO> readNotification(
+            @AuthenticationPrincipal Long memberId,
+            @PathVariable(value = "notification_id") Long notificationId
+    );
+    @Operation(summary = "모든 알림 읽음 처리", description = "모든 알림을 읽음 처리합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공")
+    })
+    whoreads.backend.global.response.ApiResponse<Void> readAllNotifications(
+            @AuthenticationPrincipal Long memberId
+    );
 
-    @Operation(summary = "알림 읽음 처리 (내역 삭제)", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
+    @Operation(summary = "알림 삭제", description = "사용자가 알림을 확인하면 해당 알림을 내역에서 즉시 삭제합니다.")
     @Parameter(name = "notification_id", description = "삭제할 알림의 고유 ID", example = "1")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "삭제 성공"),

--- a/src/main/java/whoreads/backend/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/whoreads/backend/domain/notification/converter/NotificationConverter.java
@@ -1,12 +1,13 @@
 package whoreads.backend.domain.notification.converter;
 
 import whoreads.backend.domain.notification.dto.NotificationResDTO;
+import whoreads.backend.domain.notification.entity.FollowLink;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 import whoreads.backend.domain.notification.entity.NotificationSetting;
 import whoreads.backend.domain.notification.enums.NotificationType;
 
 import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Optional;
 
 public class NotificationConverter {
 
@@ -47,8 +48,14 @@ public class NotificationConverter {
                 .title(history.getTitle())
                 .body(history.getBody())
                 .type(history.getType().name())
+                .isRead(history.isRead())
                 .createdAt(history.getCreatedAt())
-                .link(history.getLink())
+                .link(Optional.ofNullable(history.getLink())
+                        .map(link -> FollowLink.builder()
+                                .celebrityId(link.getCelebrityId())
+                                .bookId(link.getBookId())
+                                .build())
+                        .orElse(null))
                 .build();
     }
 

--- a/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import whoreads.backend.domain.notification.entity.FollowLink;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -46,7 +47,8 @@ public class NotificationResDTO {
             String type,
             String title,
             String body,
-            String link,
+            FollowLink link,
+            boolean isRead,
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ){}

--- a/src/main/java/whoreads/backend/domain/notification/entity/FollowLink.java
+++ b/src/main/java/whoreads/backend/domain/notification/entity/FollowLink.java
@@ -1,0 +1,14 @@
+package whoreads.backend.domain.notification.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+@Embeddable
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FollowLink {
+    private Long bookId;
+    private Long celebrityId;
+}

--- a/src/main/java/whoreads/backend/domain/notification/entity/NotificationHistory.java
+++ b/src/main/java/whoreads/backend/domain/notification/entity/NotificationHistory.java
@@ -30,6 +30,14 @@ public class NotificationHistory extends BaseEntity {
     @Column(nullable = false)
     private String body;
 
-    @Column()
-    private String link;
+    @Embedded
+    private FollowLink link;
+    
+    @Builder.Default
+    private boolean isRead = false;
+
+    public void setRead()
+    {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/whoreads/backend/domain/notification/enums/NotificationMessageType.java
+++ b/src/main/java/whoreads/backend/domain/notification/enums/NotificationMessageType.java
@@ -12,7 +12,7 @@ import java.util.concurrent.ThreadLocalRandom;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationMessageType {
-    NEW_FOLLOW_BOOK("%s의 서재에 새 책이 추가됐어요!", "『%s』 %s") {
+    NEW_FOLLOW_BOOK("[%s]의 서재에 새 책이 추가됐어요!", "[%s-%s]") {
         @Override
         public String[] generate(NotificationEvent event) {
             if (event instanceof NotificationEvent.FollowEvent e) {

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -22,7 +22,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomaticall=true,clearAutomatically = true)
     @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
     void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -2,6 +2,7 @@ package whoreads.backend.domain.notification.repository;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 
@@ -20,4 +21,8 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
             Pageable pageable);
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
+    void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
+++ b/src/main/java/whoreads/backend/domain/notification/repository/NotificationHistoryRepository.java
@@ -22,7 +22,7 @@ public interface NotificationHistoryRepository extends JpaRepository<Notificatio
 
     void deleteByCreatedAtBefore(LocalDateTime cutoff);
 
-    @Modifying(flushAutomaticall=true,clearAutomatically = true)
+    @Modifying(clearAutomatically = true)
     @Query("UPDATE NotificationHistory n SET n.isRead = true WHERE n.member.id = :memberId")
     void setReadAllNotifications(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
@@ -5,6 +5,8 @@ import whoreads.backend.domain.notification.dto.NotificationResDTO;
 
 public interface NotificationHistoryService {
    NotificationResDTO.TotalInboxDTO getNotificationHistory(Long memberId, Long cursor, int size);
-   void readNotification(Long memberId, Long notificationId);
+   NotificationResDTO.HistoryDTO readNotification(Long memberId, Long notificationId);
+   Void readAllNotifications(Long memberId);
    void saveHistory(Long memberId, FcmMessageDTO dto);
+   void deleteNotification(Long memberId,Long notificationId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
@@ -9,6 +9,7 @@ import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.domain.notification.converter.NotificationConverter;
 import whoreads.backend.domain.notification.dto.FcmMessageDTO;
 import whoreads.backend.domain.notification.dto.NotificationResDTO;
+import whoreads.backend.domain.notification.entity.FollowLink;
 import whoreads.backend.domain.notification.entity.NotificationHistory;
 import whoreads.backend.domain.notification.enums.NotificationType;
 import whoreads.backend.domain.notification.repository.NotificationHistoryRepository;
@@ -38,14 +39,34 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
 
     @Override
     @Transactional
-    public void readNotification(Long memberId, Long notificationId) {
+    public NotificationResDTO.HistoryDTO readNotification(Long memberId, Long notificationId) {
         // 이 알림의 권한이 사용자인지 확인
+        NotificationHistory history = notificationHistoryRepository.findById(notificationId).orElseThrow(()->
+                new CustomException(ErrorCode.RESOURCE_NOT_FOUND,"알림이 존재하지 않습니다."));
+        if (!Objects.equals(history.getMember().getId(), memberId))
+            throw new CustomException(ErrorCode.ACCESS_DENIED,"사용자의 알림이 아닙니다.");
+        history.setRead();
+        notificationHistoryRepository.save(history);
+        return NotificationConverter.toHistoryDTO(history);
+    }
+
+    @Transactional
+    @Override
+    public void deleteNotification(Long memberId,Long notificationId) {
         NotificationHistory history = notificationHistoryRepository.findById(notificationId).orElseThrow(()->
                 new CustomException(ErrorCode.RESOURCE_NOT_FOUND,"알림이 존재하지 않습니다."));
         if (!Objects.equals(history.getMember().getId(), memberId))
             throw new CustomException(ErrorCode.ACCESS_DENIED,"사용자의 알림이 아닙니다.");
         notificationHistoryRepository.delete(history);
     }
+
+    @Transactional
+    @Override
+    public Void readAllNotifications(Long memberId) {
+        notificationHistoryRepository.setReadAllNotifications(memberId);
+        return null;
+    }
+
     @Transactional
     public void saveHistory(Long memberId, FcmMessageDTO dto) {
         NotificationHistory history = NotificationHistory.builder()
@@ -53,6 +74,7 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
                 .title(dto.getTitle())
                 .body(dto.getBody())
                 .type(NotificationType.valueOf(dto.getType()))
+                .link(FollowLink.builder().celebrityId(dto.getCelebrityId()).bookId(dto.getBookId()).build())
                 .build();
         notificationHistoryRepository.save(history);
     }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -57,11 +57,13 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                         .setTitle(dto.getTitle())
                         .setBody(dto.getBody())
                         .build())
-                // ios 전용 설정 ( 알림 클릭 시 동작 및 소리 )
-                .setApnsConfig(ApnsConfig.builder()
-                        .setAps(Aps.builder()
-                                .setCategory("CLICK_ACTION")
-                                .setSound("default")
+                // 안드로이드 설정 추가
+                .setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH) // 즉시 발송
+                        .setNotification(AndroidNotification.builder()
+                                .setChannelId("high_importance_channel") // 프런트와 일치 필수
+                                .setIcon("app_logo") // 💡 사진에 올린 파일명 (확장자 제외)
+                                .setClickAction("FLUTTER_NOTIFICATION_CLICK") // 백그라운드 클릭 핸들링용
                                 .build())
                         .build())
                 // 커스텀 데이터 ( 프론트 확인용 )
@@ -86,6 +88,14 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                     .setNotification(Notification.builder()
                             .setTitle(dto.getTitle())
                             .setBody(dto.getBody())
+                            .build())
+                    .setAndroidConfig(AndroidConfig.builder()
+                            .setPriority(AndroidConfig.Priority.HIGH)
+                            .setNotification(AndroidNotification.builder()
+                                    .setChannelId("high_importance_channel")
+                                    .setIcon("app_logo") // 💡 파일명 매칭
+                                    .setClickAction("FLUTTER_NOTIFICATION_CLICK")
+                                    .build())
                             .build())
                     .putData("title", dto.getTitle())
                     .putData("body", dto.getBody())

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -87,13 +87,6 @@ public class NotificationPushServiceImpl implements NotificationPushService {
                             .setTitle(dto.getTitle())
                             .setBody(dto.getBody())
                             .build())
-                    // ios 전용 설정 ( 알림 클릭 시 동작 및 소리 )
-                    .setApnsConfig(ApnsConfig.builder()
-                            .setAps(Aps.builder()
-                                    .setCategory("CLICK_ACTION")
-                                    .setSound("default")
-                                    .build())
-                            .build())
                     .putData("title", dto.getTitle())
                     .putData("body", dto.getBody())
                     .putData("type", dto.getType());

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationScheduler.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationScheduler.java
@@ -53,7 +53,7 @@ public class NotificationScheduler {
     @Transactional
     @Scheduled(cron = "0 0 0 * * *",zone = "Asia/Seoul") // 매일 자정 실행
     public void deleteOldNotifications() {
-        LocalDateTime cutoff = LocalDateTime.now().minusDays(30);
+        LocalDateTime cutoff = LocalDateTime.now().minusDays(7);
         notificationHistoryRepository.deleteByCreatedAtBefore(cutoff);
     }
     /*

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
@@ -27,7 +27,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
         validateAuthentication(memberId);
         ReadingSessionResponse.StartResult result = readingSessionService.startSession(memberId);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.created("독서 세션을 시작했습니다.", result));
+                .body(ApiResponse.created("독서 세션을 시작했습니다.", result).withServerTime());
     }
 
     @Override
@@ -38,7 +38,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.pauseSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 일시정지했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 일시정지했습니다.").withServerTime());
     }
 
     @Override
@@ -49,7 +49,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.resumeSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 재개했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 재개했습니다.").withServerTime());
     }
 
     @Override
@@ -60,7 +60,7 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
     ) {
         validateAuthentication(memberId);
         readingSessionService.completeSession(sessionId, memberId);
-        return ResponseEntity.ok(ApiResponse.success("독서 세션을 완료했습니다."));
+        return ResponseEntity.ok(ApiResponse.success("독서 세션을 완료했습니다.").withServerTime());
     }
 
     private void validateAuthentication(Long memberId) {

--- a/src/main/java/whoreads/backend/global/config/SecurityErrorHandler.java
+++ b/src/main/java/whoreads/backend/global/config/SecurityErrorHandler.java
@@ -1,6 +1,5 @@
 package whoreads.backend.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +10,7 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
 import whoreads.backend.global.response.ApiResponse;
 
 import java.io.IOException;

--- a/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
@@ -1,7 +1,5 @@
 package whoreads.backend.global.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -43,11 +41,6 @@ public class SwaggerConfig {
                 .addServersItem(new Server().url("https://api.whoreads.kro.kr").description("Production"))
                 .addSecurityItem(securityRequirement)
                 .components(components);
-    }
-
-    @Bean
-    public ModelResolver modelResolver(ObjectMapper objectMapper) {
-        return new ModelResolver(objectMapper);
     }
 
     @Bean

--- a/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
@@ -1,8 +1,6 @@
 package whoreads.backend.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.swagger.v3.core.jackson.ModelResolver;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.Components;
@@ -17,7 +15,6 @@ import io.swagger.v3.oas.models.servers.Server;
 import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class SwaggerConfig {
@@ -46,14 +43,6 @@ public class SwaggerConfig {
                 .addServersItem(new Server().url("https://api.whoreads.kro.kr").description("Production"))
                 .addSecurityItem(securityRequirement)
                 .components(components);
-    }
-
-    @Bean
-    @Primary
-    public ObjectMapper objectMapper() {
-        return JsonMapper.builder()
-                .propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE)
-                .build();
     }
 
     @Bean

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -26,8 +26,8 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
-    `@JsonProperty`("server_time")
-    `@JsonFormat`(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
+    @JsonProperty("server_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
     private final ZonedDateTime serverTime;
 
     @JsonProperty("result")

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -26,8 +26,8 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
-    @JsonProperty("server_time")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    `@JsonProperty`("server_time")
+    `@JsonFormat`(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXXX", timezone = "Asia/Seoul")
     private final ZonedDateTime serverTime;
 
     @JsonProperty("result")

--- a/src/main/java/whoreads/backend/global/response/ApiResponse.java
+++ b/src/main/java/whoreads/backend/global/response/ApiResponse.java
@@ -1,15 +1,19 @@
 package whoreads.backend.global.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
 
 @Getter
 @Builder
-@JsonPropertyOrder({"is_success", "code", "message", "result"})
+@JsonPropertyOrder({"is_success", "code", "message", "server_time", "result"})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
 
@@ -22,8 +26,22 @@ public class ApiResponse<T> {
     @JsonProperty("message")
     private final String message;
 
+    @JsonProperty("server_time")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final ZonedDateTime serverTime;
+
     @JsonProperty("result")
     private final T result;
+
+    public ApiResponse<T> withServerTime() {
+        return ApiResponse.<T>builder()
+                .isSuccess(this.isSuccess)
+                .code(this.code)
+                .message(this.message)
+                .serverTime(ZonedDateTime.now(ZoneId.of("Asia/Seoul")))
+                .result(this.result)
+                .build();
+    }
 
     public static <T> ApiResponse<T> success(T result) {
         return ApiResponse.<T>builder()


### PR DESCRIPTION
## 📝 작업 요약
- develop 브랜치에 누적된 변경사항을 main으로 동기화

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] CI/CD 파이프라인 구축 (GitHub Actions Blue/Green 배포, docker-compose 기반 인프라)
- [x] Spring Boot 4.0.5 / springdoc 3.0.2 의존성 업그레이드 (#143)
- [x] ReadingSession API 응답에 서울 기준 serverTime 필드 추가 (#134)
- [x] SwaggerConfig @Primary ObjectMapper 제거로 Spring Boot 자동설정 복원 (#138)
- [x] ApiResponse 어노테이션 백틱 제거 및 Jackson 3 호환성 수정
- [x] nginx sed BRE 패턴 수정 및 letsencrypt 볼륨 마운트 추가
- [x] 배포 스크립트 인프라 컨테이너 충돌 방지 로직 개선

## 🔍 리뷰 포인트
- **인프라**: Blue/Green 배포 전환 로직 및 nginx 설정 업데이트 흐름
- **보안**: GitHub Actions vars/secrets 분리 적용 여부

## 📸 테스트 결과 (선택 사항)
- CD Staging 정상 배포 확인 (develop push 시 자동 배포)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?