### PR TITLE
[feat] ReadingSession 공통 사전 작업: SUSPENDED 상태 및 lastHeartbeatAt 추가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push Docker image
@@ -52,8 +52,8 @@ jobs:
           context: .
           push: true
           tags: |
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
-            ${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.environment }}-${{ github.sha }}
+            ${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -93,7 +93,7 @@ jobs:
             NETWORK_NAME="whoreads-network"
             NGINX_CONTAINER="whoreads-nginx"
             NGINX_CONF="$DEPLOY_DIR/nginx/conf.d/default.conf"
-            DOCKER_IMAGE="${{ secrets.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}"
+            DOCKER_IMAGE="${{ vars.DOCKER_USERNAME }}/whoreads:${{ inputs.docker_tag }}"
             CONTAINER_PREFIX="whoreads-${ENVIRONMENT}"
 
             # ========================================

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -69,8 +69,8 @@ jobs:
       - name: Copy Nginx template to EC2
         uses: appleboy/scp-action@v0.1.7
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "nginx/default.conf.template"
           target: "~/whoreads/"
@@ -79,8 +79,8 @@ jobs:
       - name: Deploy to EC2
         uses: appleboy/ssh-action@v1.0.3
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USER }}
+          host: ${{ vars.EC2_HOST }}
+          username: ${{ vars.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
           script: |
             set -e
@@ -172,10 +172,10 @@ jobs:
               --name "${CONTAINER_PREFIX}-$NEW" \
               --network "$NETWORK_NAME" \
               -e SPRING_PROFILES_ACTIVE=${{ inputs.spring_profile }} \
-              -e DB_HOST="${{ secrets.RDS_HOST }}" \
-              -e DB_PORT="${{ secrets.DB_PORT }}" \
-              -e DB_NAME="${{ secrets.DB_NAME }}" \
-              -e DB_USERNAME="${{ secrets.DB_USER }}" \
+              -e DB_HOST="${{ vars.DB_HOST }}" \
+              -e DB_PORT="${{ vars.DB_PORT }}" \
+              -e DB_NAME="${{ vars.DB_NAME }}" \
+              -e DB_USERNAME="${{ vars.DB_USER }}" \
               -e DB_PASSWORD="${{ secrets.DB_PASSWORD }}" \
               -e REDIS_HOST="whoreads-redis" \
               -e MAIL_ID="${{ secrets.MAIL_ID }}" \

--- a/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // loadUserByUsername 대신 새로 만든 loadUserById를 호출
             UserDetails userDetails = customUserDetailsService.loadUserById(memberId);
 
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(memberId, null, userDetails.getAuthorities());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
 
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 

--- a/src/main/java/whoreads/backend/domain/book/controller/BookController.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/BookController.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+import whoreads.backend.auth.principal.CustomUserDetails;
 import whoreads.backend.domain.book.controller.docs.BookControllerDocs;
 import whoreads.backend.domain.book.dto.BookDetailResponse;
 import whoreads.backend.domain.book.dto.BookRequest;
@@ -74,8 +75,8 @@ public class BookController implements BookControllerDocs {
 
     private Long resolveCurrentMemberId() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null && authentication.getPrincipal() instanceof Long) {
-            return (Long) authentication.getPrincipal();
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails.getMember().getId();
         }
         return null;
     }

--- a/src/main/java/whoreads/backend/domain/book/controller/BookController.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/BookController.java
@@ -1,10 +1,13 @@
 package whoreads.backend.domain.book.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import whoreads.backend.domain.book.controller.docs.BookControllerDocs;
 import whoreads.backend.domain.book.dto.BookDetailResponse;
@@ -22,6 +25,7 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/books")
 @RequiredArgsConstructor
+@Validated // 바꾼 이유: @RequestParam, @PathVariable에 설정한 제약조건을 활성화
 public class BookController implements BookControllerDocs {
 
     private final AladinBookService aladinBookService;
@@ -36,42 +40,34 @@ public class BookController implements BookControllerDocs {
     }
 
     @Override
-    @GetMapping("/{bookId}")
-    public BookResponse getBook(@PathVariable Long bookId) {
-        Book book = bookService.getBook(bookId);
-        return BookResponse.from(book);
-    }
-
-    @Override
-    @GetMapping("/search")
-    public List<BookResponse> aladinSearchBooks(@RequestParam String keyword) {
+    @GetMapping("/aladin")
+    public List<BookResponse> aladinSearchBooks(
+            @RequestParam @NotBlank(message = "알라딘 검색어는 필수입니다.") String keyword) { // 바꾼 이유: 빈 문자열 요청 차단
         return aladinBookService.searchBooks(keyword);
     }
 
     @Override
     @PostMapping
-    public ResponseEntity<BookResponse> registerBook(@RequestBody @Valid BookRequest request) {
-        Book savedBook = bookService.registerBook(request.toEntity());
-        return ResponseEntity.ok(BookResponse.from(savedBook));
+    public ResponseEntity<BookResponse> registerBook(@RequestBody @Valid BookRequest request) { // 바꾼 이유: @Valid 추가
+        Book book = bookService.registerBook(request);
+        return ResponseEntity.ok(BookResponse.from(book));
     }
 
     @Override
-    @GetMapping("/ranks")
-    public ResponseEntity<List<BookResponse>> getMostRecommendedBooks(@RequestParam(defaultValue = "20") int limit) {
+    @GetMapping("/most-recommended")
+    public ResponseEntity<List<BookResponse>> getMostRecommendedBooks(
+            @RequestParam(defaultValue = "20") @Positive(message = "가져올 개수는 1 이상이어야 합니다.") int limit) { // 바꾼 이유: limit에 음수나 0이 들어오면 에러가 나므로 @Positive 추가
         List<Book> books = bookService.getMostRecommendedBooks(limit);
-
         List<BookResponse> response = books.stream()
                 .map(BookResponse::from)
                 .collect(Collectors.toList());
-
         return ResponseEntity.ok(response);
     }
 
     @Override
     @GetMapping("/{bookId}/detail")
     public ApiResponse<BookDetailResponse> getBookDetail(
-            @PathVariable Long bookId
-    ) {
+            @PathVariable @Positive(message = "올바른 책 ID를 입력해주세요.") Long bookId) { // 바꾼 이유: ID값 검증
         Long memberId = resolveCurrentMemberId();
         return ApiResponse.success(bookService.getBookDetail(bookId, memberId));
     }
@@ -88,14 +84,12 @@ public class BookController implements BookControllerDocs {
     @GetMapping("/themes/{theme}")
     public ResponseEntity<List<BookResponse>> getBooksByTheme(
             @PathVariable TopicTag theme,
-            @RequestParam(defaultValue = "20") int limit
+            @RequestParam(defaultValue = "20") @Positive int limit // 바꾼 이유: 음수 리밋 방지
     ) {
         List<Book> books = bookService.getBooksByTheme(theme, limit);
-
         List<BookResponse> response = books.stream()
                 .map(BookResponse::from)
                 .collect(Collectors.toList());
-
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,19 +23,26 @@ import java.util.List;
 public interface BookControllerDocs {
 
     @Operation(summary = "도서 목록 조회 및 검색 (내부 DB)", description = "우리 DB에 저장된 도서 목록을 조회합니다. keyword가 있으면 제목/저자로 검색합니다.")
-    List<BookResponse> getAllBooks(@Parameter(description = "검색어 (비워두면 전체 조회)") @RequestParam(required = false) String keyword);
+    List<BookResponse> getAllBooks(
+            @Parameter(description = "검색어 (비워두면 전체 조회)") @RequestParam(required = false) String keyword
+    );
 
-    @Operation(summary = "책 상세 조회", description = "책 ID로 상세 정보를 조회합니다.")
-    BookResponse getBook(@Parameter(description = "책 ID") @PathVariable Long bookId);
-
-    @Operation(summary = "책 검색 (알라딘)", description = "제목 또는 저자로 책을 알라딘으로 검색합니다.")
-    List<BookResponse> aladinSearchBooks(@Parameter(description = "검색어") @RequestParam String keyword);
+    @Operation(summary = "알라딘 도서 검색", description = "알라딘 API를 사용하여 외부 도서를 검색합니다. (검색어 필수)")
+    List<BookResponse> aladinSearchBooks(
+            @Parameter(description = "검색어 (공백 불가)", required = true)
+            @RequestParam @NotBlank(message = "알라딘 검색어는 필수입니다.") String keyword
+    );
 
     @Operation(summary = "책 등록 (중복 체크)", description = "책 정보를 등록합니다. 만약 제목과 작가가 동일한 책이 이미 있다면, 새로 저장하지 않고 기존 책 정보를 반환합니다.")
-    ResponseEntity<BookResponse> registerBook(@RequestBody BookRequest request);
+    ResponseEntity<BookResponse> registerBook(
+            @RequestBody BookRequest request
+    );
 
-    @Operation(summary = "가장 많이 추천된 책 (TOP 20)", description = "유명인들이 가장 많이 언급(인용)한 책들을 추천 수 내림차순으로 조회합니다.")
-    ResponseEntity<List<BookResponse>> getMostRecommendedBooks(@Parameter(description = "가져올 책 개수 (기본값 20)") @RequestParam(defaultValue = "20") int limit);
+    @Operation(summary = "가장 많이 추천된 책 (TOP 20)", description = "유명인들이 가장 많이 언급(인용)한 책들을 추천 수 내림차순으로 조회합니다. limit은 1 이상이어야 합니다.")
+    ResponseEntity<List<BookResponse>> getMostRecommendedBooks(
+            @Parameter(description = "가져올 책 개수 (기본값 20, 1 이상)")
+            @RequestParam(defaultValue = "20") @Positive(message = "가져올 개수는 1 이상이어야 합니다.") int limit
+    );
 
     @Operation(
             summary = "책 상세페이지 조회",
@@ -42,15 +51,17 @@ public interface BookControllerDocs {
     )
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 (ID가 양수가 아님)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 책 ID", content = @Content)
     })
     whoreads.backend.global.response.ApiResponse<BookDetailResponse> getBookDetail(
-            @Parameter(description = "책 ID") @PathVariable Long bookId
+            @Parameter(description = "책 ID (1 이상)", required = true)
+            @PathVariable @Positive(message = "올바른 책 ID를 입력해주세요.") Long bookId
     );
 
-    @Operation(summary = "주제별 추천 책 목록 조회", description = "특정 주제(SOCIETY, HUMAN_UNDERSTANDING 등)에 맞는 유명인 추천 책 목록을 조회합니다.")
+    @Operation(summary = "주제별 책 조회", description = "특정 주제(테마)에 맞는 책 목록을 가져옵니다. limit은 1 이상이어야 합니다.")
     ResponseEntity<List<BookResponse>> getBooksByTheme(
-            @Parameter(description = "주제 태그 (Enum 값)") @PathVariable TopicTag theme,
-            @Parameter(description = "가져올 책 개수 (기본값 20)") @RequestParam(defaultValue = "20") int limit
+            @Parameter(description = "주제 태그", required = true) @PathVariable TopicTag theme,
+            @Parameter(description = "가져올 개수 (1 이상)") @RequestParam(defaultValue = "20") @Positive int limit
     );
 }

--- a/src/main/java/whoreads/backend/domain/book/dto/BookRequest.java
+++ b/src/main/java/whoreads/backend/domain/book/dto/BookRequest.java
@@ -1,6 +1,9 @@
 package whoreads.backend.domain.book.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.URL;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import whoreads.backend.domain.book.entity.Book;
@@ -10,21 +13,29 @@ import whoreads.backend.domain.book.entity.Book;
 public class BookRequest {
 
     @NotBlank(message = "제목은 필수입니다.")
+    @Size(max = 255, message = "제목은 255자 이내여야 합니다.") // 바꾼 이유: DB 컬럼 사이즈 초과 시 발생하는 500 에러를 막기 위해 길이 제한 추가
     private String title;
 
     @NotBlank(message = "작가 이름은 필수입니다.")
+    @Size(max = 100, message = "작가 이름은 100자 이내여야 합니다.") // 바꾼 이유: 길이 제한 추가
     private String authorName;
 
+    @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 이상한 문자열이 링크로 들어오는 것을 방지
     private String coverUrl;
+
+    @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 올바른 URL 형식 확인
     private String link;
+
     private String genre;
+
+    @Positive(message = "총 페이지 수는 0보다 커야 합니다.") // 바꾼 이유: 총 페이지 수가 0이거나 음수인 논리적 오류 차단
     private Integer totalPage;
 
     // DTO -> Entity 변환 메서드
     public Book toEntity() {
         return Book.builder()
-                .title(title)
-                .authorName(authorName)
+                .title(title.trim()) // 바꾼 이유: 앞뒤 공백으로 인한 중복 데이터 생성 방지
+                .authorName(authorName.trim())
                 .coverUrl(coverUrl)
                 .link(link)
                 .genre(genre)

--- a/src/main/java/whoreads/backend/domain/book/entity/Book.java
+++ b/src/main/java/whoreads/backend/domain/book/entity/Book.java
@@ -22,10 +22,10 @@ public class Book extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255) // 길이 명시
     private String title;
 
-    @Column(name = "author_name", nullable = false)
+    @Column(name = "author_name", nullable = false, length = 100) // DTO 사이즈와 동일하게 명시
     private String authorName;
 
     @Column(columnDefinition = "TEXT")
@@ -41,10 +41,10 @@ public class Book extends BaseEntity {
     private Integer totalPage;
 
     // 책을 조회하면, 이 책에 달린 인용들도 같이 가져올 수 있도록 연결
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true) // 고아 객체 해결
     private List<BookQuote> quotes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<CelebrityBook> celebrityBookList = new ArrayList<>();
 

--- a/src/main/java/whoreads/backend/domain/book/entity/Book.java
+++ b/src/main/java/whoreads/backend/domain/book/entity/Book.java
@@ -4,11 +4,9 @@ import jakarta.persistence.*;
 import lombok.*;
 import whoreads.backend.domain.celebrity.entity.CelebrityBook;
 import whoreads.backend.global.entity.BaseEntity;
-
 import java.util.ArrayList;
 import java.util.List;
 
-// @Builder 삭제 (생성자에 있으므로 중복 제거)
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/whoreads/backend/domain/book/entity/Book.java
+++ b/src/main/java/whoreads/backend/domain/book/entity/Book.java
@@ -8,13 +8,12 @@ import whoreads.backend.global.entity.BaseEntity;
 import java.util.ArrayList;
 import java.util.List;
 
-@Builder
+// @Builder 삭제 (생성자에 있으므로 중복 제거)
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "book", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"title", "author_name"}) // 제목+저자 중복 방지 (선택 사항이나 추천)
+        @UniqueConstraint(columnNames = {"title", "author_name"})
 })
 public class Book extends BaseEntity {
 
@@ -22,10 +21,10 @@ public class Book extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 255) // 길이 명시
+    @Column(nullable = false, length = 255)
     private String title;
 
-    @Column(name = "author_name", nullable = false, length = 100) // DTO 사이즈와 동일하게 명시
+    @Column(name = "author_name", nullable = false, length = 100)
     private String authorName;
 
     @Column(columnDefinition = "TEXT")
@@ -41,14 +40,13 @@ public class Book extends BaseEntity {
     private Integer totalPage;
 
     // 책을 조회하면, 이 책에 달린 인용들도 같이 가져올 수 있도록 연결
-    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true) // 고아 객체 해결
+    @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookQuote> quotes = new ArrayList<>();
 
     @OneToMany(mappedBy = "book", cascade = CascadeType.ALL, orphanRemoval = true)
-    @Builder.Default
     private List<CelebrityBook> celebrityBookList = new ArrayList<>();
 
-    @Builder
+    @Builder // 생성자 레벨 빌더만 유지
     public Book(String title, String authorName, String link, String genre, String coverUrl, Integer totalPage) {
         this.title = title;
         this.authorName = authorName;

--- a/src/main/java/whoreads/backend/domain/book/service/AladinBookService.java
+++ b/src/main/java/whoreads/backend/domain/book/service/AladinBookService.java
@@ -27,10 +27,15 @@ public class AladinBookService {
     private String aladinUrl;
 
     public List<BookResponse> searchBooks(String keyword) {
+        // 바꾼 이유: 키워드가 없는데 API를 찌르면 알라딘 쪽 에러가 발생하므로 서버 단에서 조기 차단
+        if (keyword == null || keyword.isBlank()) {
+            return Collections.emptyList();
+        }
+
         try {
             String requestUrl = UriComponentsBuilder.fromUriString(aladinUrl)
                     .queryParam("ttbkey", ttbKey)
-                    .queryParam("Query", keyword)
+                    .queryParam("Query", keyword.trim())
                     .queryParam("QueryType", "Title")
                     .queryParam("MaxResults", 10)
                     .queryParam("start", 1)
@@ -50,9 +55,9 @@ public class AladinBookService {
 
             return response.getItems().stream()
                     .map(item -> BookResponse.builder()
-                            .id(0L) // DB에 저장 안 된 상태
+                            .id(null) // DB에 저장 안 된 상태 (바꾼 이유: 0L보다 null이 'DB에 없음'을 논리적으로 명확히 나타냄)
                             .title(item.getTitle())
-                            .authorName(item.getAuthor())
+                            .authorName(item.getAuthor() != null ? item.getAuthor() : "저자 미상")
                             .coverUrl(item.getCover())
                             .totalPage(null)
                             .build())

--- a/src/main/java/whoreads/backend/domain/book/service/AladinBookService.java
+++ b/src/main/java/whoreads/backend/domain/book/service/AladinBookService.java
@@ -3,6 +3,7 @@ package whoreads.backend.domain.book.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -18,7 +19,8 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class AladinBookService {
 
-    private final RestTemplate restTemplate = new RestTemplate();
+    // 바꾼 이유: RestTemplateBuilder 임포트 에러 해결 및 @RequiredArgsConstructor 충돌 방지
+    private final RestTemplate restTemplate = createRestTemplate();
 
     @Value("${aladin.api.key}")
     private String ttbKey;
@@ -26,8 +28,15 @@ public class AladinBookService {
     @Value("${aladin.api.url}")
     private String aladinUrl;
 
-    public List<BookResponse> searchBooks(String keyword) {
-        // 바꾼 이유: 키워드가 없는데 API를 찌르면 알라딘 쪽 에러가 발생하므로 서버 단에서 조기 차단
+    // 타임아웃을 설정한 RestTemplate을 반환하는 메서드
+    private RestTemplate createRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000); // 3000ms = 3초 (연결 타임아웃)
+        factory.setReadTimeout(3000);    // 3000ms = 3초 (응답 타임아웃)
+        return new RestTemplate(factory);
+    }
+
+    public List<BookResponse> searchBooks(String keyword) {  // 바꾼 이유: 키워드가 없는데 API를 찌르면 알라딘 쪽 에러가 발생하므로 서버 단에서 조기 차단
         if (keyword == null || keyword.isBlank()) {
             return Collections.emptyList();
         }

--- a/src/main/java/whoreads/backend/domain/book/service/BookService.java
+++ b/src/main/java/whoreads/backend/domain/book/service/BookService.java
@@ -1,12 +1,11 @@
 package whoreads.backend.domain.book.service;
 
-import jakarta.persistence.EntityNotFoundException;
+import org.springframework.data.domain.PageRequest; // 바꾼 이유: PageRequest 임포트 추가 (페이징 처리 에러 해결)
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import whoreads.backend.domain.book.dto.BookDetailResponse;
+import whoreads.backend.domain.book.dto.BookRequest;
 import whoreads.backend.domain.book.entity.Book;
 import whoreads.backend.domain.book.entity.BookQuote;
 import whoreads.backend.domain.book.repository.BookQuoteRepository;
@@ -15,7 +14,6 @@ import whoreads.backend.domain.library.repository.UserBookRepository;
 import whoreads.backend.domain.quote.entity.QuoteSource;
 import whoreads.backend.domain.quote.repository.QuoteSourceRepository;
 import whoreads.backend.domain.topic.entity.TopicTag;
-import whoreads.backend.domain.topic.repository.TopicBookRepository;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
@@ -34,47 +32,21 @@ public class BookService {
     private final BookQuoteRepository bookQuoteRepository;
     private final QuoteSourceRepository quoteSourceRepository;
     private final UserBookRepository userBookRepository;
-    private final TopicBookRepository topicBookRepository;
 
-    // 책 상세 조회
-    public Book getBook(Long bookId) {
-        return bookRepository.findById(bookId)
-                .orElseThrow(() -> new EntityNotFoundException("책을 찾을 수 없습니다. ID=" + bookId));
-    }
-
-    public List<Book> getAllBooks(String keyword) {
-        if (keyword == null || keyword.isBlank()) {
-            return bookRepository.findAll();
-        }
-        return bookRepository.searchByKeyword(keyword);
-    }
-
-    // 어드민용 책 등록 (동시성 문제 해결)
     @Transactional
-    public Book registerBook(Book book) {
-        return bookRepository.findByTitleAndAuthorName(book.getTitle(), book.getAuthorName())
-                .orElseGet(() -> {
-                    try {
-                        return bookRepository.save(book);
-                    } catch (DataIntegrityViolationException e) {
-                        // 동시에 누군가 저장했다면 다시 조회해서 반환
-                        return bookRepository.findByTitleAndAuthorName(book.getTitle(), book.getAuthorName())
-                                .orElseThrow(() -> new IllegalStateException("책 저장 중 알 수 없는 오류 발생"));
-                    }
-                });
+    public Book registerBook(BookRequest request) {
+        String trimmedTitle = request.getTitle().trim();
+        String trimmedAuthor = request.getAuthorName().trim();
+
+        return bookRepository.findByTitleAndAuthorName(trimmedTitle, trimmedAuthor)
+                .orElseGet(() -> bookRepository.save(request.toEntity()));
     }
 
-    // 가장 많이 추천된 책 TOP N 조회
-    public List<Book> getMostRecommendedBooks(int limit) {
-        return bookQuoteRepository.findMostRecommendedBooks(PageRequest.of(0, limit));
-    }
-
-    // 책 상세페이지 조회
     public BookDetailResponse getBookDetail(Long bookId, Long memberId) {
+        // 바꾼 이유: EntityNotFoundException 대신 직접 정의한 CustomException과 ErrorCode를 사용하도록 통일
         Book book = bookRepository.findById(bookId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
 
-        // 인용 + 유명인 JOIN FETCH (contextScore DESC 정렬)
         List<BookQuote> bookQuotes = bookQuoteRepository.findByBookIdWithFetchJoin(bookId);
 
         // 출처 배치 조회
@@ -85,10 +57,10 @@ public class BookService {
         Map<Long, QuoteSource> sourceMap = quoteIds.isEmpty()
                 ? Collections.emptyMap()
                 : quoteSourceRepository.findByQuoteIdIn(quoteIds).stream()
-                        .collect(Collectors.toMap(
-                                src -> src.getQuote().getId(),
-                                Function.identity()
-                        ));
+                .collect(Collectors.toMap(
+                        src -> src.getQuote().getId(),
+                        Function.identity()
+                ));
 
         // 응답 조립
         BookDetailResponse response = BookDetailResponse.of(book, bookQuotes, sourceMap);
@@ -104,14 +76,25 @@ public class BookService {
         return response;
     }
 
+    public List<Book> getAllBooks(String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return bookRepository.findAll();
+        }
+        return bookRepository.searchByKeyword(keyword.trim());
+    }
+
+    public List<Book> getMostRecommendedBooks(int limit) {
+        // 바꾼 이유: limit 숫자 하나만 넣으면 에러가 나므로, PageRequest 객체로 생성해서 넘겨줌
+        return bookQuoteRepository.findMostRecommendedBooks(PageRequest.of(0, limit));
+    }
+
     // 주제별 책 조회 로직
     public List<Book> getBooksByTheme(TopicTag theme, int limit) {
         // 프론트에서 TOP_20을 요청했을 땐 기존 로직 재사용
         if (theme == TopicTag.TOP_20) {
             return getMostRecommendedBooks(limit);
         }
-
-        // 그 외의 주제들은 TopicBook 매핑 테이블에서 조회
-        return topicBookRepository.findBooksByThemeName(theme, PageRequest.of(0, limit));
+        // 그 외의 주제들은 Topic... (기존 로직 유지)
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/whoreads/backend/domain/celebrity/controller/CelebrityController.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/controller/CelebrityController.java
@@ -1,7 +1,9 @@
 package whoreads.backend.domain.celebrity.controller;
 
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import whoreads.backend.domain.celebrity.controller.docs.CelebrityControllerDocs;
 import whoreads.backend.domain.celebrity.dto.CelebrityResponse;
@@ -13,6 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/celebrities")
 @RequiredArgsConstructor
+@Validated // 바꾼 이유: @PathVariable로 들어오는 id 값을 검증하기 위해 클래스 레벨에 활성화
 public class CelebrityController implements CelebrityControllerDocs {
 
     private final CelebrityService celebrityService;
@@ -28,7 +31,9 @@ public class CelebrityController implements CelebrityControllerDocs {
     // 2. 상세 조회
     @Override
     @GetMapping("/{id}")
-    public ResponseEntity<CelebrityResponse> getCelebrityById(@PathVariable Long id) {
+    public ResponseEntity<CelebrityResponse> getCelebrityById(
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id) {
+        // 바꾼 이유: 음수나 0 같은 비정상적인 ID가 들어오는 것을 컨트롤러 단에서 미리 차단
         return ResponseEntity.ok(celebrityService.getCelebrity(id));
     }
 }

--- a/src/main/java/whoreads/backend/domain/celebrity/controller/docs/CelebrityControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/controller/docs/CelebrityControllerDocs.java
@@ -2,7 +2,11 @@ package whoreads.backend.domain.celebrity.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -21,8 +25,13 @@ public interface CelebrityControllerDocs {
     );
 
     @Operation(summary = "유명인 상세 조회", description = "ID로 특정 유명인 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 (ID가 1 이상이 아님)"), // 바꾼 이유: Validation 추가로 인한 400 에러 응답 문서화
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유명인 ID", content = @Content) // 바꾼 이유: CustomException 추가로 인한 404 에러 응답 문서화
+    })
     ResponseEntity<CelebrityResponse> getCelebrityById(
-            @Parameter(description = "유명인 ID")
-            @PathVariable Long id
+            @Parameter(description = "유명인 ID (1 이상)", required = true)
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id // 바꾼 이유: 파라미터 제약조건 문서화
     );
 }

--- a/src/main/java/whoreads/backend/domain/celebrity/repository/CelebrityRepository.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/repository/CelebrityRepository.java
@@ -26,7 +26,7 @@ public interface CelebrityRepository extends JpaRepository<Celebrity, Long> {
     @EntityGraph(attributePaths = "jobTags")
     Optional<Celebrity> findById(Long id);
 
-    @Query("SELECT c FROM Celebrity c " +
+    @Query("SELECT DISTINCT c FROM Celebrity c " +
             "LEFT JOIN FETCH c.celebrityBookList cb " +
             "LEFT JOIN FETCH cb.book " + // Book까지 한꺼번에 긁어와야 함!
             "WHERE c.id IN :ids")

--- a/src/main/java/whoreads/backend/domain/celebrity/service/CelebrityService.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/service/CelebrityService.java
@@ -1,6 +1,5 @@
 package whoreads.backend.domain.celebrity.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,6 +7,8 @@ import whoreads.backend.domain.celebrity.dto.CelebrityResponse;
 import whoreads.backend.domain.celebrity.entity.Celebrity;
 import whoreads.backend.domain.celebrity.entity.CelebrityTag;
 import whoreads.backend.domain.celebrity.repository.CelebrityRepository;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,8 +37,9 @@ public class CelebrityService {
 
     // 상세 조회 (ID)
     public CelebrityResponse getCelebrity(Long id) {
+        // 바꾼 이유: 기본 EntityNotFoundException 대신 프로젝트 공통 CustomException과 이미 정의된 CELEBRITY_NOT_FOUND 사용
         Celebrity celebrity = celebrityRepository.findById(id)
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유명인입니다. ID=" + id));
+                .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
 
         return CelebrityResponse.from(celebrity);
     }

--- a/src/main/java/whoreads/backend/domain/dna/controller/DnaControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/dna/controller/DnaControllerDocs.java
@@ -43,7 +43,7 @@ public interface DnaControllerDocs {
 
     @Operation(
             summary = "테스트 결과 조회",
-            description = "사용자의 DNA 테스트 결과를 조회합니다.\\n" +
+            description = "사용자의 DNA 테스트 결과를 조회합니다.\n" +
                     "테스트를 하지 않았을 경우 404가 반환됩니다."
     )
     @ApiResponses({

--- a/src/main/java/whoreads/backend/domain/dna/enums/TrackCode.java
+++ b/src/main/java/whoreads/backend/domain/dna/enums/TrackCode.java
@@ -14,4 +14,12 @@ public enum TrackCode {
     FOCUS("재미/몰입");
 
     private final String description;
+
+    public static TrackCode fromName(String name) {
+        if (name == null) return null;
+        for (TrackCode code : values()) {
+            if (code.name().equalsIgnoreCase(name)) return code;
+        }
+        return null;
+    }
 }

--- a/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
+++ b/src/main/java/whoreads/backend/domain/dna/service/DnaService.java
@@ -27,11 +27,15 @@
     import java.util.List;
     import java.util.Map;
     import java.util.stream.Collectors;
+    import org.slf4j.Logger;
+    import org.slf4j.LoggerFactory;
 
     @Service
     @RequiredArgsConstructor
     @Transactional(readOnly = true)
     public class DnaService {
+
+        private static final Logger log = LoggerFactory.getLogger(DnaService.class);
 
         private final CelebrityBookRepository celebrityBookRepository;
 
@@ -77,7 +81,7 @@
             if (member.getDnaType() == null)
                 throw new CustomException(ErrorCode.DNA_TEST_NOT_COMPLETED);
 
-            TrackCode trackCode = TrackCode.valueOf(member.getDnaType());
+            TrackCode trackCode = TrackCode.fromName(member.getDnaType());
             String celebrityName = member.getDnaTypeName();
 
             Celebrity celebrity = celebrityRepository.findByName(celebrityName)
@@ -111,7 +115,7 @@
 
             // [중요 로그] 사용자의 점수가 어떻게 나왔는지 확인
             userScores.forEach((genre, score) ->
-                    System.out.println("사용자 점수 -> 장르: " + genre + ", 점수: " + score));
+                    log.debug("사용자 점수 -> 장르: {}, 점수: {}", genre, score));
 
             // 3. Pool 5명 중 최종 승자(1명) 계산
             Celebrity winner = null;
@@ -122,7 +126,7 @@
                 List<CelebrityBook> books = booksByCelebrity.getOrDefault(celebrity.getId(), new ArrayList<>());
 
                 // 로그로 확인 (이제 절대 0이 나올 수 없습니다)
-                System.out.println("ID: " + celebrity.getId() + " | 이름: " + celebrity.getName() + " | 실제 책 권수: " + books.size());
+                log.debug("ID: {} | 이름: {} | 실제 책 권수: {}", celebrity.getId(), celebrity.getName(), books.size());
 
                 double currentScore = calculateFitScore(books, userScores);
 
@@ -131,14 +135,14 @@
                     winner = celebrity;
                 } else if (currentScore == maxScore) {
                     // 적합도 점수가 같으면 책을 더 많이 추천한 사람 우선
-                    if (winner == null || celebrity.getCelebrityBookList().size() > winner.getCelebrityBookList().size()) {
+                    if (winner == null || booksByCelebrity.getOrDefault(celebrity.getId(), new ArrayList<>()).size() > booksByCelebrity.getOrDefault(winner.getId(), new ArrayList<>()).size()) {
                         winner = celebrity;
                     }
                 }
             }
 
             if (winner == null)
-                throw new RuntimeException("매칭된 인물이 없습니다.");
+                throw new CustomException(ErrorCode.DNA_TEST_NOT_FOUND_RESULT_CELEBRITY);
 
             // 결과값을 DB의 Member 엔티티에 저장
             Member member = memberRepository.findById(memberId)
@@ -180,7 +184,7 @@
                     }
                 }
                 // 여기에 로그 삽입!
-                System.out.println(code.getDescription() + " | 일치 개수: " + count + " (전체: " + totalCount + ")");
+                log.debug("{} | 일치 개수: {} (전체: {})", code.getDescription(), count, totalCount);
 
                 ratios.put(code, totalCount > 0 ? (double) count / totalCount : 0.0);
             }

--- a/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
@@ -1,8 +1,10 @@
 package whoreads.backend.domain.member.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import whoreads.backend.domain.member.controller.docs.MemberControllerDocs;
 import whoreads.backend.domain.member.dto.MemberRequest;
@@ -14,6 +16,7 @@ import whoreads.backend.global.response.ApiResponse;
 import java.util.List;
 
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
@@ -41,12 +44,12 @@ public class MemberController implements MemberControllerDocs {
 
     @PostMapping("/follow/{celebrityId}")
     @Override
-    public ApiResponse<Void> followCelebrity(@PathVariable Long celebrityId, @AuthenticationPrincipal Long memberId) {
+    public ApiResponse<Void> followCelebrity(@PathVariable @Positive Long celebrityId, @AuthenticationPrincipal Long memberId) {
         memberService.followCelebrity(memberId, celebrityId);
         return ApiResponse.success("팔로우가 완료됐습니다.");
     }
 
-    @PostMapping ("me/fcm-tokens")
+    @PostMapping ("/me/fcm-tokens")
     @Override
     public ApiResponse<Void> updateFcmToken(
             @AuthenticationPrincipal Long memberId,
@@ -55,7 +58,7 @@ public class MemberController implements MemberControllerDocs {
         notificationTokenService.updateToken(memberId,fcmRequest.fcmToken());
         return ApiResponse.success("토큰이 성공적으로 등록되었습니다.");
     }
-    @DeleteMapping("me/fcm-tokens")
+    @DeleteMapping("/me/fcm-tokens")
     @Override
     public ApiResponse<Void> deleteFcmToken(
             @AuthenticationPrincipal Long memberId) {

--- a/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -42,17 +42,33 @@ public interface MemberControllerDocs {
     @Operation(
             summary = "사용자 개인 정보 조회"
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음"),
+    })
     ApiResponse<MemberResDto.MemberInfo> getMyInfo(@AuthenticationPrincipal Long memberId);
 
 
     @Operation(
             summary = "사용자가 팔로우하는 유명인 리스트 조회"
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음"),
+    })
     ApiResponse<List<MemberResDto.CelebrityFollow>> getMyFollows(@AuthenticationPrincipal Long memberId);
 
 
     @Operation(
             summary = "사용자가 유명인을 팔로우할 때 사용하는 API"
     )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "팔로우 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증되지 않은 사용자"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "회원 없음 / 유명인 없음"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 팔로우 중인 유명인"),
+    })
     ApiResponse<Void> followCelebrity(@PathVariable Long celebrityId, @AuthenticationPrincipal Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/member/converter/MemberConverter.java
+++ b/src/main/java/whoreads/backend/domain/member/converter/MemberConverter.java
@@ -46,7 +46,7 @@ public class MemberConverter {
                 .loginId(member.getLoginId())
                 .createdAt(member.getCreatedAt())
                 .status(member.getStatus())
-                .trackCode(member.getDnaType() != null ? TrackCode.valueOf(member.getDnaType()) : null)
+                .trackCode(TrackCode.fromName(member.getDnaType()))
                 .fcmToken(member.getFcmToken())
                 .build();
     }

--- a/src/main/java/whoreads/backend/domain/member/entity/MemberCelebrity.java
+++ b/src/main/java/whoreads/backend/domain/member/entity/MemberCelebrity.java
@@ -11,7 +11,7 @@ import whoreads.backend.global.entity.BaseEntity;
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "celebrity_id"}))
 public class MemberCelebrity extends BaseEntity {
 
     @Id

--- a/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
@@ -28,7 +28,7 @@ public class FcmMessageDTO {
                 .body(generated[1])
                 .type(type.name()); // DB 저장용 타입 이름 (FOLLOW, ROUTINE 등)
 
-        if (event != null && type.equals(NotificationType.FOLLOW) &&
+        if (event != null && type == NotificationType.FOLLOW &&
                 event instanceof NotificationEvent.FollowEvent followEvent)
         {
             builder.celebrityId(followEvent.celebId());

--- a/src/main/java/whoreads/backend/domain/quote/controller/QuoteController.java
+++ b/src/main/java/whoreads/backend/domain/quote/controller/QuoteController.java
@@ -1,8 +1,10 @@
 package whoreads.backend.domain.quote.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import whoreads.backend.domain.quote.controller.docs.QuoteControllerDocs;
@@ -16,13 +18,14 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/quotes")
 @RequiredArgsConstructor
+@Validated // 바꾼 이유: @PathVariable의 제약 조건(@Positive)을 활성화하기 위함
 public class QuoteController implements QuoteControllerDocs {
 
     private final QuoteService quoteService;
 
     @Override
     @PostMapping
-    public ResponseEntity<Void> registerQuote(@RequestBody @Valid QuoteRequest request) { // @Valid 추가
+    public ResponseEntity<Void> registerQuote(@RequestBody @Valid QuoteRequest request) { // 바꾼 이유: @Valid 추가하여 DTO 검증 활성화
         Long createdId = quoteService.registerQuote(request);
 
         // 생성된 리소스의 URI 생성 (예: /api/quotes/1) - 상세 조회 API가 있다면 유용
@@ -36,13 +39,17 @@ public class QuoteController implements QuoteControllerDocs {
 
     @Override
     @GetMapping("/books/{bookId}")
-    public ResponseEntity<List<QuoteResponse>> getQuotesByBook(@PathVariable Long bookId) {
+    public ResponseEntity<List<QuoteResponse>> getQuotesByBook(
+            @PathVariable @Positive(message = "올바른 책 ID를 입력해주세요.") Long bookId) {
+        // 바꾼 이유: 비정상적인 ID 요청을 컨트롤러에서 미리 차단
         return ResponseEntity.ok(quoteService.getQuotesByBook(bookId));
     }
 
     @Override
     @GetMapping("/celebrities/{celebrityId}")
-    public ResponseEntity<List<QuoteResponse>> getQuotesByCelebrity(@PathVariable Long celebrityId) {
+    public ResponseEntity<List<QuoteResponse>> getQuotesByCelebrity(
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long celebrityId) {
+        // 바꾼 이유: 비정상적인 ID 요청을 컨트롤러에서 미리 차단
         return ResponseEntity.ok(quoteService.getQuotesByCelebrity(celebrityId));
     }
 }

--- a/src/main/java/whoreads/backend/domain/quote/controller/docs/QuoteControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/quote/controller/docs/QuoteControllerDocs.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,18 +17,32 @@ import java.util.List;
 @Tag(name = "Quote (인용)", description = "유명인-책 인용 및 추천 정보 관리 API")
 public interface QuoteControllerDocs {
 
-    @Operation(summary = "인용 등록", description = "유명인이 책에 대해 언급한 인용(Quote)과 출처(Source), 맥락(Context) 정보를 한 번에 등록합니다.")
+    @Operation(summary = "인용 등록", description = "유명인이 책에 대해 언급한 인용(Quote)과 출처(Source), 맥락(Context) 정보를 한 번에 등록합니다. 제약조건(@URL 등)이 강화되었습니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "인용 등록 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 (책이나 유명인 ID 없음)"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (값 누락 또는 URL 형식 오류 등)"),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 책/유명인"),
             @ApiResponse(responseCode = "500", description = "서버 에러")
     })
     ResponseEntity<Void> registerQuote(@RequestBody QuoteRequest request);
 
     @Operation(summary = "책별 인용 조회", description = "특정 책에 달린 유명인들의 인용 목록을 조회합니다. (맥락 점수 높은 순)")
-    ResponseEntity<List<QuoteResponse>> getQuotesByBook(@Parameter(description = "책 ID") @PathVariable Long bookId);
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 (책 ID가 1 이상이 아님)")
+    })
+    ResponseEntity<List<QuoteResponse>> getQuotesByBook(
+            @Parameter(description = "책 ID (1 이상)")
+            @PathVariable @Positive(message = "올바른 책 ID를 입력해주세요.") Long bookId
+    );
 
     @Operation(summary = "인물별 인용 조회 (가상 서재)", description = "특정 유명인이 남긴 인용(읽은 책) 목록을 조회합니다. (맥락 점수 높은 순)")
-    ResponseEntity<List<QuoteResponse>> getQuotesByCelebrity(@Parameter(description = "인물 ID") @PathVariable Long celebrityId);
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 파라미터 (유명인 ID가 1 이상이 아님)")
+    })
+    ResponseEntity<List<QuoteResponse>> getQuotesByCelebrity(
+            @Parameter(description = "인물 ID (1 이상)")
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long celebrityId
+    );
 }

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -1,7 +1,11 @@
 package whoreads.backend.domain.quote.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
 import org.hibernate.validator.constraints.URL;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,20 +18,20 @@ public class QuoteRequest {
 
     // 1. 기본 정보
     @NotNull(message = "책 ID는 필수입니다.")
-    @Positive(message = "책 ID는 양수여야 합니다.") // 바꾼 이유: ID 값에 음수가 들어오는 것을 방지
+    @Positive(message = "책 ID는 양수여야 합니다.")
     private Long bookId;
 
     @NotNull(message = "유명인 ID는 필수입니다.")
-    @Positive(message = "유명인 ID는 양수여야 합니다.") // 바꾼 이유: ID 값에 음수가 들어오는 것을 방지
+    @Positive(message = "유명인 ID는 양수여야 합니다.")
     private Long celebrityId;
 
     @NotBlank(message = "인용 문구는 필수입니다.")
-    @Size(max = 2000, message = "인용 문구는 2000자를 초과할 수 없습니다.") // 길이 제한 추가
+    @Size(max = 2000, message = "인용 문구는 2000자를 초과할 수 없습니다.")
     private String originalText;
 
-    private Quote.Language language; // 없을 경우 로직에서 기본값 처리 가능
+    private Quote.Language language;
 
-    @Min(value = 0, message = "맥락 점수는 0 이상이어야 합니다.") // 바꾼 이유: 점수가 음수로 들어오는 논리적 오류 차단
+    @Min(value = 0, message = "맥락 점수는 0 이상이어야 합니다.")
     private int contextScore;
 
     // 2. 출처 정보 (선택)
@@ -35,12 +39,13 @@ public class QuoteRequest {
     private SourceInfo source;
 
     // 3. 맥락 정보 (선택)
+    @Valid // 누락되었던 검증 활성화
     private ContextInfo context;
 
     @Getter
     @NoArgsConstructor
     public static class SourceInfo {
-        @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 잘못된 형식의 URL이 DB에 저장되는 것 방지
+        @URL(message = "올바른 URL 형식이어야 합니다.")
         private String url;
         private QuoteSourceType type;
         private String timestamp;
@@ -51,9 +56,15 @@ public class QuoteRequest {
     @NoArgsConstructor
     public static class ContextInfo {
         @Size(max = 1000, message = "계기 설명은 1000자 이내여야 합니다.")
-        private String how;  // 계기
-        private String when; // 시기
-        private String why;  // 이유
-        private String help; // 도움
+        private String how;
+
+        @Size(max = 500, message = "시기 설명은 500자 이내여야 합니다.")
+        private String when;
+
+        @Size(max = 1000, message = "이유 설명은 1000자 이내여야 합니다.")
+        private String why;
+
+        @Size(max = 1000, message = "도움 설명은 1000자 이내여야 합니다.")
+        private String help;
     }
 }

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -1,6 +1,11 @@
 package whoreads.backend.domain.quote.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.hibernate.validator.constraints.URL;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import whoreads.backend.domain.quote.entity.Quote;
@@ -12,19 +17,23 @@ public class QuoteRequest {
 
     // 1. 기본 정보
     @NotNull(message = "책 ID는 필수입니다.")
+    @Positive(message = "책 ID는 양수여야 합니다.") // 바꾼 이유: ID 값에 음수가 들어오는 것을 방지
     private Long bookId;
 
     @NotNull(message = "유명인 ID는 필수입니다.")
+    @Positive(message = "유명인 ID는 양수여야 합니다.") // 바꾼 이유: ID 값에 음수가 들어오는 것을 방지
     private Long celebrityId;
 
-    @NotNull(message = "인용 문구는 필수입니다.")
+    @NotBlank(message = "인용 문구는 필수입니다.")
     private String originalText;
 
     private Quote.Language language; // 없을 경우 로직에서 기본값 처리 가능
 
+    @Min(value = 0, message = "맥락 점수는 0 이상이어야 합니다.") // 바꾼 이유: 점수가 음수로 들어오는 논리적 오류 차단
     private int contextScore;
 
     // 2. 출처 정보 (선택)
+    @Valid // 바꾼 이유: 중첩된 객체(SourceInfo) 내부의 필드 검증(@URL 등)을 활성화하기 위해 추가
     private SourceInfo source;
 
     // 3. 맥락 정보 (선택)
@@ -33,6 +42,7 @@ public class QuoteRequest {
     @Getter
     @NoArgsConstructor
     public static class SourceInfo {
+        @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 잘못된 형식의 URL이 DB에 저장되는 것 방지
         private String url;
         private QuoteSourceType type;
         private String timestamp;

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -31,8 +31,10 @@ public class QuoteRequest {
 
     private Quote.Language language;
 
+    // 바꾼 이유: primitive int는 누락 시 0으로 바인딩되어 검증을 우회하므로 Integer + @NotNull로 변경
+    @NotNull(message = "맥락 점수는 필수입니다.")
     @Min(value = 0, message = "맥락 점수는 0 이상이어야 합니다.")
-    private int contextScore;
+    private Integer contextScore;
 
     // 2. 출처 정보 (선택)
     @Valid // 바꾼 이유: 중첩된 객체(SourceInfo) 내부의 필드 검증(@URL 등)을 활성화하기 위해 추가

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -29,6 +29,7 @@ public class QuoteRequest {
     @Size(max = 2000, message = "인용 문구는 2000자를 초과할 수 없습니다.")
     private String originalText;
 
+    @NotNull(message = "언어 설정은 필수입니다.")
     private Quote.Language language;
 
     // 바꾼 이유: primitive int는 누락 시 0으로 바인딩되어 검증을 우회하므로 Integer + @NotNull로 변경

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -1,10 +1,7 @@
 package whoreads.backend.domain.quote.dto;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.*;
 import org.hibernate.validator.constraints.URL;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -25,6 +22,7 @@ public class QuoteRequest {
     private Long celebrityId;
 
     @NotBlank(message = "인용 문구는 필수입니다.")
+    @Size(max = 2000, message = "인용 문구는 2000자를 초과할 수 없습니다.") // 길이 제한 추가
     private String originalText;
 
     private Quote.Language language; // 없을 경우 로직에서 기본값 처리 가능
@@ -52,6 +50,7 @@ public class QuoteRequest {
     @Getter
     @NoArgsConstructor
     public static class ContextInfo {
+        @Size(max = 1000, message = "계기 설명은 1000자 이내여야 합니다.")
         private String how;  // 계기
         private String when; // 시기
         private String why;  // 이유

--- a/src/main/java/whoreads/backend/domain/quote/service/QuoteService.java
+++ b/src/main/java/whoreads/backend/domain/quote/service/QuoteService.java
@@ -1,6 +1,5 @@
 package whoreads.backend.domain.quote.service;
 
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -20,6 +19,8 @@ import whoreads.backend.domain.quote.entity.QuoteSource;
 import whoreads.backend.domain.quote.repository.QuoteContextRepository;
 import whoreads.backend.domain.quote.repository.QuoteRepository;
 import whoreads.backend.domain.quote.repository.QuoteSourceRepository;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -38,14 +39,13 @@ public class QuoteService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional
-    public Long registerQuote(QuoteRequest request) { // Void -> Long (ID 반환)
-
+    public Long registerQuote(QuoteRequest request) {
+        // 바꾼 이유: EntityNotFoundException 대신 프로젝트 공통 예외인 CustomException과 정의된 ErrorCode 사용
         Book book = bookRepository.findById(request.getBookId())
-                .orElseThrow(() -> new EntityNotFoundException("책이 없습니다. ID=" + request.getBookId()));
+                .orElseThrow(() -> new CustomException(ErrorCode.BOOK_NOT_FOUND));
         Celebrity celebrity = celebrityRepository.findById(request.getCelebrityId())
-                .orElseThrow(() -> new EntityNotFoundException("유명인이 없습니다. ID=" + request.getCelebrityId()));
+                .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
 
-        // 1. Quote 저장
         Quote quote = Quote.builder()
                 .originalText(request.getOriginalText())
                 .language(request.getLanguage())
@@ -55,14 +55,12 @@ public class QuoteService {
 
         quoteRepository.save(quote);
 
-        // 2. BookQuote 연결
         BookQuote bookQuote = BookQuote.builder()
                 .book(book)
                 .quote(quote)
                 .build();
         bookQuoteRepository.save(bookQuote);
 
-        // 3. QuoteSource 저장
         if (request.getSource() != null) {
             QuoteSource source = QuoteSource.builder()
                     .quote(quote)
@@ -73,7 +71,6 @@ public class QuoteService {
             quoteSourceRepository.save(source);
         }
 
-        // 4. QuoteContext 저장
         if (request.getContext() != null) {
             QuoteContext context = QuoteContext.builder()
                     .quote(quote)
@@ -84,10 +81,13 @@ public class QuoteService {
                     .build();
             quoteContextRepository.save(context);
         }
+
         applicationEventPublisher.publishEvent(
-                new NotificationEvent.FollowEvent
-                        (celebrity.getId(), celebrity.getName(),
-                                book.getId(), book.getTitle(),book.getAuthorName()));
+                new NotificationEvent.FollowEvent(
+                        celebrity.getId(), celebrity.getName(),
+                        book.getId(), book.getTitle(), book.getAuthorName()
+                )
+        );
 
         return quote.getId();
     }

--- a/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
@@ -49,6 +49,7 @@ public class ReadingSession extends BaseEntity {
         this.member = member;
         this.status = SessionStatus.IN_PROGRESS;
         this.totalMinutes = 0L;
+        this.lastHeartbeatAt = LocalDateTime.now(); // 세션 시작 시 초기화
     }
 
     public void pause() {

--- a/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
@@ -12,6 +12,7 @@ import whoreads.backend.global.entity.BaseEntity;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
@@ -65,6 +66,7 @@ public class ReadingSession extends BaseEntity {
     }
 
     public void updateHeartbeat(LocalDateTime heartbeatAt) {
+        Objects.requireNonNull(heartbeatAt, "heartbeatAt must not be null");
         this.lastHeartbeatAt = heartbeatAt;
     }
 

--- a/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
@@ -72,6 +72,9 @@ public class ReadingSession extends BaseEntity {
     }
 
     public void suspend() {
+        if (this.status != SessionStatus.IN_PROGRESS && this.status != SessionStatus.PAUSED) {
+            throw new IllegalStateException("IN_PROGRESS 또는 PAUSED 상태의 세션만 중단할 수 있습니다. 현재 상태: " + this.status);
+        }
         this.status = SessionStatus.SUSPENDED;
     }
 

--- a/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/entity/ReadingSession.java
@@ -37,6 +37,9 @@ public class ReadingSession extends BaseEntity {
     @Column(name = "finished_at")
     private LocalDateTime finishedAt;
 
+    @Column(name = "last_heartbeat_at")
+    private LocalDateTime lastHeartbeatAt;
+
     @OneToMany(mappedBy = "readingSession", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReadingInterval> intervals = new ArrayList<>();
 
@@ -59,6 +62,14 @@ public class ReadingSession extends BaseEntity {
             throw new IllegalStateException("일시정지된 세션만 재개할 수 있습니다. 현재 상태: " + this.status);
         }
         this.status = SessionStatus.IN_PROGRESS;
+    }
+
+    public void updateHeartbeat(LocalDateTime heartbeatAt) {
+        this.lastHeartbeatAt = heartbeatAt;
+    }
+
+    public void suspend() {
+        this.status = SessionStatus.SUSPENDED;
     }
 
     public void complete() {

--- a/src/main/java/whoreads/backend/domain/readingsession/enums/SessionStatus.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/enums/SessionStatus.java
@@ -3,5 +3,6 @@ package whoreads.backend.domain.readingsession.enums;
 public enum SessionStatus {
     IN_PROGRESS,
     PAUSED,
-    COMPLETED
+    COMPLETED,
+    SUSPENDED
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
@@ -30,6 +30,7 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
         // 이미 진행 중이거나 일시정지된 세션이 있는지 확인
+        // SUSPENDED 세션은 의도적으로 제외: 자동 중단된 세션이 새 세션 시작을 막지 않도록 함
         readingSessionRepository.findByMemberIdAndStatusIn(
                 memberId, List.of(SessionStatus.IN_PROGRESS, SessionStatus.PAUSED)
         ).ifPresent(s -> {

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
@@ -94,7 +94,7 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
     @Override
     public void heartbeat(Long sessionId, Long memberId) {
         ReadingSession session = findByIdAndValidateOwnership(sessionId, memberId);
-        session.heartbeat();
+        session.updateHeartbeat(LocalDateTime.now());
     }
 
     private ReadingSession findByIdAndValidateOwnership(Long sessionId, Long memberId) {

--- a/src/main/java/whoreads/backend/domain/topic/controller/docs/TopicControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/topic/controller/docs/TopicControllerDocs.java
@@ -9,6 +9,6 @@ import java.util.List;
 @Tag(name = "Topic (주제 큐레이션)", description = "주제별 추천 도서 조회 API")
 public interface TopicControllerDocs {
 
-    @Operation(summary = "주제별 도서 목록 조회", description = "메인 화면에 노출되는 주제별 추천 도서 목록을 조회합니다.")
+    @Operation(summary = "주제별 도서 목록 조회", description = "메인 화면에 노출되는 주제별 추천 도서 목록을 조회합니다.") // 바꾼 이유: API의 목적을 명확히 함
     ResponseEntity<List<TopicResponse>> getAllTopics();
 }

--- a/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
+++ b/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
@@ -14,8 +14,8 @@ import java.util.List;
 public interface TopicBookRepository extends JpaRepository<TopicBook, Long> {
 
     // 특정 주제에 연결된 책들 조회 (Book 정보도 같이 가져옴 - N+1 방지)
-    @Query("SELECT tb FROM TopicBook tb JOIN FETCH tb.book WHERE tb.topic = :topic")
-    List<TopicBook> findByTopicWithFetchJoin(@Param("topic") Topic topic);
+    @Query("SELECT tb FROM TopicBook tb JOIN FETCH tb.book JOIN FETCH tb.topic WHERE tb.topic IN :topics")
+    List<TopicBook> findAllByTopicInWithFetchJoin(@Param("topics") List<Topic> topics);
     
     // TopicBook과 연관된 Topic을 조인해서 Enum(TopicTag) 이름으로 바로 필터링하고, Book만 가져옴
     @Query("SELECT tb.book FROM TopicBook tb JOIN tb.topic t WHERE t.name = :theme")

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -10,8 +10,8 @@ import whoreads.backend.domain.topic.entity.TopicBook;
 import whoreads.backend.domain.topic.repository.TopicBookRepository;
 import whoreads.backend.domain.topic.repository.TopicRepository;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,18 +24,18 @@ public class TopicService {
 
     public List<TopicResponse> getAllTopics() {
         List<Topic> topics = topicRepository.findAll();
-        List<TopicResponse> responses = new ArrayList<>();
 
-        for (Topic topic : topics) {
-            // 해당 주제에 연결된 책들 가져오기 (Fetch Join)
-            List<Book> books = topicBookRepository.findByTopicWithFetchJoin(topic).stream()
-                    .map(TopicBook::getBook)
-                    .collect(Collectors.toList());
+        // N+1 문제 해결: IN 쿼리로 한 번에 가져와서 Map으로 그룹화
+        Map<Topic, List<Book>> booksByTopic = topicBookRepository
+                .findAllByTopicInWithFetchJoin(topics)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        TopicBook::getTopic,
+                        Collectors.mapping(TopicBook::getBook, Collectors.toList())
+                ));
 
-            // DTO 변환
-            responses.add(TopicResponse.of(topic, books));
-        }
-
-        return responses;
+        return topics.stream()
+                .map(topic -> TopicResponse.of(topic, booksByTopic.getOrDefault(topic, List.of())))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -38,4 +38,4 @@ public class TopicService {
 
         return responses;
     }
-}
+}qw

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -25,6 +25,10 @@ public class TopicService {
     public List<TopicResponse> getAllTopics() {
         List<Topic> topics = topicRepository.findAll();
 
+        // 바꾼 이유: topics가 비어있을 때 빈 컬렉션으로 IN 쿼리를 날려 발생하는 에러(또는 불필요한 쿼리) 방지
+        if (topics.isEmpty()) {
+            return List.of();
+        }
         // N+1 문제 해결: IN 쿼리로 한 번에 가져와서 Map으로 그룹화
         Map<Topic, List<Book>> booksByTopic = topicBookRepository
                 .findAllByTopicInWithFetchJoin(topics)

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -30,16 +30,17 @@ public class TopicService {
             return List.of();
         }
         // N+1 문제 해결: IN 쿼리로 한 번에 가져와서 Map으로 그룹화
-        Map<Topic, List<Book>> booksByTopic = topicBookRepository
+        // 바꾼 이유: Topic 객체 자체를 Key로 쓰면 1차 캐시 이탈 시 매핑이 깨지므로 고유한 ID(Long)를 Key로 사용
+        Map<Long, List<Book>> booksByTopicId = topicBookRepository
                 .findAllByTopicInWithFetchJoin(topics)
                 .stream()
                 .collect(Collectors.groupingBy(
-                        TopicBook::getTopic,
+                        tb -> tb.getTopic().getId(),
                         Collectors.mapping(TopicBook::getBook, Collectors.toList())
                 ));
 
         return topics.stream()
-                .map(topic -> TopicResponse.of(topic, booksByTopic.getOrDefault(topic, List.of())))
+                .map(topic -> TopicResponse.of(topic, booksByTopicId.getOrDefault(topic.getId(), List.of())))
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -38,4 +38,4 @@ public class TopicService {
 
         return responses;
     }
-}qw
+}

--- a/src/main/java/whoreads/backend/global/exception/ErrorCode.java
+++ b/src/main/java/whoreads/backend/global/exception/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),
 
     // MemberCelebrity
-    ALREADY_FOLLOWING(HttpStatus.ALREADY_REPORTED, "이미 팔로우 중인 유명인 입니다."),
+    ALREADY_FOLLOWING(HttpStatus.CONFLICT, "이미 팔로우 중인 유명인 입니다."),
 
     // Book
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "책을 찾을 수 없습니다."),

--- a/src/main/java/whoreads/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/whoreads/backend/global/exception/GlobalExceptionHandler.java
@@ -89,14 +89,6 @@ public class GlobalExceptionHandler {
                 .body(ApiResponse.error(HttpStatus.METHOD_NOT_ALLOWED.value(), "허용되지 않은 메서드입니다."));
     }
 
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
-        log.error("Exception: {}", e.getMessage(), e);
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
-    }
-
     @ExceptionHandler({UsernameNotFoundException.class, BadCredentialsException.class})
     public ResponseEntity<ApiResponse<Void>> handleLoginException(Exception e) {
         log.error("Login Failure: {}", e.getMessage());
@@ -106,5 +98,13 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ApiResponse.error(errorCode.getStatus().value(), errorCode.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
+        log.error("Exception: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiResponse.error(HttpStatus.INTERNAL_SERVER_ERROR.value(), "서버 내부 오류가 발생했습니다."));
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- Task 1(heartbeat 스케줄러), Task 3(GET /active) 구현을 위한 공통 사전 작업

## 🔗 관련 이슈(있으면)
- #151

## 🛠 주요 변경 사항
- [x] `SessionStatus` enum에 `SUSPENDED` 추가
  - `PAUSED`: 사용자가 의도적으로 일시정지한 상태
  - `SUSPENDED`: heartbeat 2시간 초과 시 자동 전환 (IN_PROGRESS, PAUSED 모두 대상)
- [x] `ReadingSession` 엔티티에 `lastHeartbeatAt` 필드 추가 (nullable)
- [x] `ReadingSession`에 `updateHeartbeat()`, `suspend()` 메서드 추가

## 🔍 리뷰 포인트
- **로직**: `lastHeartbeatAt`은 nullable로 추가했습니다. 기존 세션과의 호환성 확인 부탁드립니다.
- **보안**: N/A

## 📸 테스트 결과 (선택 사항)
- 로컬 빌드 정상 확인 (`./gradlew compileJava`)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가? (해당 없음)

## 🛠 Troubleshooting (선택 사항)
- N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 열람 세션 일시 중단(SUSPEND) 기능 추가

* **개선사항**
  * API 전반 입력값 검증 강화(음수/빈값/최대길이/URL 등)
  * 검색/추천 엔드포인트 경로 변경 및 검색어 공백 정규화
  * 중복 팔로우 시 HTTP 409 응답으로 조정
  * 문서(스웨거) 보강 및 조회 쿼리 중복 제거/정확도 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->