### PR TITLE
feat: 사용자 독서 세션 설정 반환 로직 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/focusmode/entity/FocusTimerSetting.java
+++ b/src/main/java/whoreads/backend/domain/focusmode/entity/FocusTimerSetting.java
@@ -28,18 +28,26 @@ public class FocusTimerSetting extends BaseEntity {
     @Column(name = "white_noise_enabled", nullable = false)
     private Boolean whiteNoiseEnabled = false;
 
+    // 새로 추가한 필드 - 현
+    @Column(name = "timer_minutes", nullable = false)
+    private Long timerMinutes = 0L;
+
     @Builder
-    public FocusTimerSetting(Member member) {
+    public FocusTimerSetting(Member member, Long timerMinutes) {
         this.member = member;
         this.focusBlockEnabled = false;
         this.whiteNoiseEnabled = false;
+        this.timerMinutes = (timerMinutes != null) ? timerMinutes : 0L;
     }
-
     public void updateFocusBlockEnabled(Boolean enabled) {
         this.focusBlockEnabled = Boolean.TRUE.equals(enabled);
     }
 
     public void updateWhiteNoiseEnabled(Boolean enabled) {
         this.whiteNoiseEnabled = Boolean.TRUE.equals(enabled);
+    }
+
+    public void updateTimerMinutes(Long minutes) { // 추가 - 현
+        this.timerMinutes = minutes;
     }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionSettingsController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionSettingsController.java
@@ -95,4 +95,14 @@ public class ReadingSessionSettingsController implements ReadingSessionSettingsC
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
     }
+
+    @Override
+    @GetMapping("") // 추가 - 현
+    public ResponseEntity<ApiResponse<ReadingSessionResponse.SessionSettings>> getSessionSettings(
+            @AuthenticationPrincipal Long memberId
+    ) {
+        validateAuthentication(memberId);
+        ReadingSessionResponse.SessionSettings result = readingSessionSettingsService.getSessionSettings(memberId);
+        return ResponseEntity.ok(ApiResponse.success("독서 세션 설정을 성공적으로 불러왔습니다.", result));
+    }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionSettingsControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionSettingsControllerDocs.java
@@ -340,4 +340,33 @@ public interface ReadingSessionSettingsControllerDocs {
             )
             ReadingSessionRequest.UpdateBlockedApps request
     );
+
+    @Operation( // 추가 - 현
+            summary = "사용자 독서 세션 전체 설정 반환",
+            description = "클라이언트 로컬 스토리지 유실 등을 대비해 사용자의 독서 타이머, 집중 모드, 백색소음 등 모든 설정을 한 번에 반환합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                {
+                                  "is_success": true,
+                                  "code": 200,
+                                  "message": "독서 세션 설정을 성공적으로 불러왔습니다.",
+                                  "result": {
+                                    "timer_minutes": 30,
+                                    "focus_block_enabled": true,
+                                    "white_noise_enabled": false
+                                  }
+                                }
+                                """)
+                    )
+            )
+    })
+    ResponseEntity<ApiResponse<ReadingSessionResponse.SessionSettings>> getSessionSettings(
+            Long memberId
+    );
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -90,4 +90,12 @@ public class ReadingSessionResponse {
     public static class BlockedApps {
         private List<BlockedAppItem> blockedApps;
     }
+
+    @Getter
+    @Builder
+    public static class SessionSettings { // 추가 - 현
+        private Long timerMinutes;
+        private Boolean focusBlockEnabled;
+        private Boolean whiteNoiseEnabled;
+    }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsService.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsService.java
@@ -20,4 +20,6 @@ public interface ReadingSessionSettingsService {
     ReadingSessionResponse.BlockedApps getBlockedApps(Long memberId);
 
     ReadingSessionResponse.BlockedApps updateBlockedApps(Long memberId, List<BlockedAppItem> blockedApps);
+
+    ReadingSessionResponse.SessionSettings getSessionSettings(Long memberId); // 추가 - 현
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsServiceImpl.java
@@ -142,4 +142,15 @@ public class ReadingSessionSettingsServiceImpl implements ReadingSessionSettings
                             .build());
                 });
     }
+
+    @Override // 추가 - 현
+    public ReadingSessionResponse.SessionSettings getSessionSettings(Long memberId) {
+        FocusTimerSetting setting = getOrCreateSetting(memberId);
+
+        return ReadingSessionResponse.SessionSettings.builder()
+                .timerMinutes(setting.getTimerMinutes())
+                .focusBlockEnabled(setting.getFocusBlockEnabled())
+                .whiteNoiseEnabled(setting.getWhiteNoiseEnabled())
+                .build();
+    }
 }


### PR DESCRIPTION
## 📝 작업 요약
- 사용자 독서 세션 설정 반환 로직 추가

## 🛠 주요 변경 사항
- [x] 특정 도메인(reading-session)의 핵심 로직 구현
- [x] 데이터베이스 스키마(FocusTimerSettings) 추가 및 변경 사항

## 🔍 리뷰 포인트
- 요청한 내용대로 만들었는지 확인 부탁드립니다

## ✅ 체크리스트
- [x ] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **읽기 세션 설정 조회 기능 추가**
  * 사용자의 읽기 세션 설정(타이머, 포커스 모드, 화이트 노이즈)을 한 번에 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
  * 타이머 분 설정을 업데이트할 수 있는 기능이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->