### PR TITLE
미완료 독서 세션 조회 API 생성 및 스케줄러 에러 수정

### DIFF
--- a/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // loadUserByUsername 대신 새로 만든 loadUserById를 호출
             UserDetails userDetails = customUserDetailsService.loadUserById(memberId);
 
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(memberId, null, userDetails.getAuthorities());
 
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/ReadingSessionController.java
@@ -79,4 +79,11 @@ public class ReadingSessionController implements ReadingSessionControllerDocs {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
     }
+
+    @GetMapping("/incomplete")
+    public ApiResponse<ReadingSessionResponse.IncompleteResult> incompleteSession(@AuthenticationPrincipal Long memberId) {
+        ReadingSessionResponse.IncompleteResult result = readingSessionService.getIncompleteSession(memberId);
+
+        return ApiResponse.success(result);
+    }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/controller/docs/ReadingSessionControllerDocs.java
@@ -229,4 +229,11 @@ public interface ReadingSessionControllerDocs {
             Long sessionId,
             @AuthenticationPrincipal Long memberId
     );
+
+    @Operation(summary = "미완료 독서 세션 조회", description = "사용자가 이전에 종료하지 않은 독서 세션(IN_PROGRESS, PAUSED, SUSPENDED)이 있는지 조회합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "미완료 세션 조회 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "미완료된 독서 세션이 존재하지 않습니다.")
+    })
+    ApiResponse<ReadingSessionResponse.IncompleteResult> incompleteSession(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -98,4 +98,19 @@ public class ReadingSessionResponse {
         private Boolean focusBlockEnabled;
         private Boolean whiteNoiseEnabled;
     }
+
+    // 위에 SessionSettings 사용해도 될듯. 저기 있는 timerMinutes가 사용자가 설정한 시간인건가?
+    @Getter
+    @Builder
+    public static class IncompleteResult {
+        private Long sessionId;
+        private String status;   // IN_PROGRESS, PAUSED, SUSPENDED
+        private Long totalReadMinutes;
+        private Long idleMinutes;   // IN_PROGRESS인 경우 마지막 세션 이후 경과 시간
+        private Long remainingMinutes;
+
+        // 집중 모드 설정 정보
+        private Boolean focusBlockEnabled;
+        private Boolean whiteNoiseEnabled;
+    }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -1,6 +1,7 @@
 package whoreads.backend.domain.readingsession.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.readingsession.enums.SessionStatus;
@@ -99,9 +100,17 @@ public class ReadingSessionResponse {
         private Boolean whiteNoiseEnabled;
     }
 
-    // 위에 SessionSettings 사용해도 될듯. 저기 있는 timerMinutes가 사용자가 설정한 시간인건가?
     @Getter
     @Builder
+    @JsonPropertyOrder({
+            "sessionId",
+            "status",
+            "totalReadMinutes",
+            "remainingMinutes",
+            "idleMinutes",
+            "focusBlockEnabled",
+            "whiteNoiseEnabled"
+    })
     public static class IncompleteResult {
         private Long sessionId;
         private String status;   // IN_PROGRESS, PAUSED, SUSPENDED

--- a/src/main/java/whoreads/backend/domain/readingsession/enums/SessionStatus.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/enums/SessionStatus.java
@@ -2,7 +2,7 @@ package whoreads.backend.domain.readingsession.enums;
 
 public enum SessionStatus {
     IN_PROGRESS,
-    PAUSED,
+    PAUSED,   // 사용자가 의도적으로 일시정지한 상태
     COMPLETED,
-    SUSPENDED
+    SUSPENDED   // heartbeat 2시간 초과시 자동 전환되는 상태
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/repository/ReadingSessionRepository.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/repository/ReadingSessionRepository.java
@@ -16,7 +16,8 @@ public interface ReadingSessionRepository extends JpaRepository<ReadingSession, 
             "WHERE rs.member.id = :memberId AND rs.status = :status")
     Long sumTotalMinutesByMemberIdAndStatus(@Param("memberId") Long memberId, @Param("status") SessionStatus status);
 
-    Optional<ReadingSession> findByMemberIdAndStatusIn(Long memberId, List<SessionStatus> statuses);
+//    Optional<ReadingSession> findByMemberIdAndStatusIn(Long memberId, List<SessionStatus> statuses);
+    Optional<ReadingSession> findFirstByMemberIdAndStatusInOrderByCreatedAtDesc(Long memberId, List<SessionStatus> statuses);
 
     @Query("SELECT COALESCE(SUM(rs.totalMinutes), 0) FROM ReadingSession rs " +
             "WHERE rs.member.id = :memberId AND rs.status = 'COMPLETED' " +

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionScheduler.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionScheduler.java
@@ -21,7 +21,11 @@ public class ReadingSessionScheduler {
     @Transactional
     @Scheduled(fixedDelay = 60_000, zone = "Asia/Seoul")
     public void expireStaleSessions() {
-        LocalDateTime threshold = LocalDateTime.now().minusHours(5);
+        // 5 -> 2로 수정
+        LocalDateTime threshold = LocalDateTime.now().minusHours(2);
+
+        // 테스트용
+        // LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
         List<ReadingSession> staleSessions = readingSessionRepository.findStaleInProgressSessions(threshold);
 
         if (staleSessions.isEmpty()) {
@@ -32,8 +36,22 @@ public class ReadingSessionScheduler {
             session.getIntervals().stream()
                     .filter(interval -> interval.getEndTime() == null)
                     .findFirst()
-                    .ifPresent(interval -> interval.end(session.getLastHeartbeatAt()));
-            session.complete();
+//                    .ifPresent(interval -> interval.end(session.getLastHeartbeatAt()));
+
+                    .ifPresent(interval -> {
+                        LocalDateTime endTime = session.getLastHeartbeatAt();
+
+                        // 하트비트가 아예 없거나, 인터벌 시작 시간보다 과거/동일한 경우
+                        if (endTime == null || !endTime.isAfter(interval.getStartTime())) {
+                            // 에러(IllegalArgumentException)가 나지 않도록 시작 시간보다 1초 뒤로 강제 설정
+                            endTime = interval.getStartTime().plusSeconds(1);
+                        }
+
+                        // 안전하게 검증된 시간으로 인터벌 종료
+                        interval.end(endTime);
+                    });
+
+            session.suspend();
         }
 
         log.info("[ReadingSessionScheduler] stale 세션 {}건 자동 완료 처리", staleSessions.size());

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionService.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionService.java
@@ -13,4 +13,6 @@ public interface ReadingSessionService {
     void completeSession(Long sessionId, Long memberId);
 
     void heartbeat(Long sessionId, Long memberId);
+
+    ReadingSessionResponse.IncompleteResult getIncompleteSession(Long memberId);
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
@@ -3,6 +3,8 @@ package whoreads.backend.domain.readingsession.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import whoreads.backend.domain.focusmode.entity.FocusTimerSetting;
+import whoreads.backend.domain.focusmode.repository.FocusModeRepository;
 import whoreads.backend.domain.member.entity.Member;
 import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.domain.readingsession.dto.ReadingSessionResponse;
@@ -23,6 +25,7 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
 
     private final ReadingSessionRepository readingSessionRepository;
     private final MemberRepository memberRepository;
+    private final FocusModeRepository focusModeRepository;
 
     @Override
     public ReadingSessionResponse.StartResult startSession(Long memberId) {
@@ -113,5 +116,61 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
                 .filter(interval -> interval.getEndTime() == null)
                 .findFirst()
                 .ifPresent(interval -> interval.end(LocalDateTime.now()));
+    }
+
+    public ReadingSessionResponse.IncompleteResult getIncompleteSession(Long memberId) {
+        ReadingSession session = readingSessionRepository.findByMemberIdAndStatusIn(memberId,
+                List.of(SessionStatus.IN_PROGRESS, SessionStatus.PAUSED, SessionStatus.SUSPENDED)).orElse(null);
+
+        if (session == null)
+            throw new CustomException(ErrorCode.INCOMPLETE_SESSION_NOT_FOUND);
+
+        FocusTimerSetting focusSetting = focusModeRepository.findByMemberId(memberId)
+                .orElseGet(() -> FocusTimerSetting.builder()
+                        .timerMinutes(10000L) // (선택사항) 타이머 기본값 세팅
+                        .build());
+
+        long totalReadMinutes = session.calculateTotalMinutes();
+
+        if (session.getStatus() == SessionStatus.IN_PROGRESS) {
+            for (ReadingInterval interval : session.getIntervals()) {
+                if (interval.getEndTime() == null) {
+                    long currentDiff = java.time.temporal.ChronoUnit.MINUTES.between(
+                            interval.getStartTime(),
+                            java.time.LocalDateTime.now()
+                    );
+                    totalReadMinutes += currentDiff;
+                    break;
+                }
+            }
+        }
+
+        // 목표 시간(임시 60분) 기반 남은 시간 계산
+        long targetMinutes = 60L;   // 이 부분 사용자가 실제로 설정한 시간으로 받아와야됨. FocusTimerSetting 부분
+        long remainingMinutes = Math.max(0, targetMinutes - totalReadMinutes);
+
+        // 4. 공통 반환 필드 세팅 (status에 실제 DB 상태값 반영)
+        ReadingSessionResponse.IncompleteResult.IncompleteResultBuilder builder =
+                ReadingSessionResponse.IncompleteResult.builder()
+                        .sessionId(session.getId())
+                        .status(session.getStatus().name()) // 오타 수정: 실제 상태값 반환
+                        .totalReadMinutes(totalReadMinutes)
+                        .focusBlockEnabled(focusSetting.getFocusBlockEnabled())
+                        .whiteNoiseEnabled(focusSetting.getWhiteNoiseEnabled());
+
+        // 5. 실제 상태에 따른 추가 필드 조립
+        if (session.getStatus() == SessionStatus.IN_PROGRESS) {
+            long idleMinutes = java.time.temporal.ChronoUnit.MINUTES.between(
+                    session.getUpdatedAt(),
+                    java.time.LocalDateTime.now()
+            );
+            builder.idleMinutes(idleMinutes)
+                    .remainingMinutes(remainingMinutes);
+
+        } else if (session.getStatus() == SessionStatus.PAUSED) {
+            builder.remainingMinutes(remainingMinutes);
+        }
+
+        return builder.build();
     }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionServiceImpl.java
@@ -1,6 +1,7 @@
 package whoreads.backend.domain.readingsession.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import whoreads.backend.domain.focusmode.entity.FocusTimerSetting;
@@ -18,6 +19,7 @@ import whoreads.backend.global.exception.ErrorCode;
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -34,7 +36,7 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
 
         // 이미 진행 중이거나 일시정지된 세션이 있는지 확인
         // SUSPENDED 세션은 의도적으로 제외: 자동 중단된 세션이 새 세션 시작을 막지 않도록 함
-        readingSessionRepository.findByMemberIdAndStatusIn(
+        readingSessionRepository.findFirstByMemberIdAndStatusInOrderByCreatedAtDesc(
                 memberId, List.of(SessionStatus.IN_PROGRESS, SessionStatus.PAUSED)
         ).ifPresent(s -> {
             throw new CustomException(ErrorCode.SESSION_ALREADY_ACTIVE);
@@ -98,6 +100,10 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
     public void heartbeat(Long sessionId, Long memberId) {
         ReadingSession session = findByIdAndValidateOwnership(sessionId, memberId);
         session.updateHeartbeat(LocalDateTime.now());
+
+        LocalDateTime now = LocalDateTime.now();
+
+        log.info("[세션 ID: {}] 하트비트 업데이트 시간: {}", sessionId, now);
     }
 
     private ReadingSession findByIdAndValidateOwnership(Long sessionId, Long memberId) {
@@ -118,17 +124,16 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
                 .ifPresent(interval -> interval.end(LocalDateTime.now()));
     }
 
+    @Override
     public ReadingSessionResponse.IncompleteResult getIncompleteSession(Long memberId) {
-        ReadingSession session = readingSessionRepository.findByMemberIdAndStatusIn(memberId,
+        ReadingSession session = readingSessionRepository.findFirstByMemberIdAndStatusInOrderByCreatedAtDesc(memberId,
                 List.of(SessionStatus.IN_PROGRESS, SessionStatus.PAUSED, SessionStatus.SUSPENDED)).orElse(null);
 
         if (session == null)
             throw new CustomException(ErrorCode.INCOMPLETE_SESSION_NOT_FOUND);
 
         FocusTimerSetting focusSetting = focusModeRepository.findByMemberId(memberId)
-                .orElseGet(() -> FocusTimerSetting.builder()
-                        .timerMinutes(10000L) // (선택사항) 타이머 기본값 세팅
-                        .build());
+                .orElseGet(() -> FocusTimerSetting.builder().build());
 
         long totalReadMinutes = session.calculateTotalMinutes();
 
@@ -145,15 +150,14 @@ public class ReadingSessionServiceImpl implements ReadingSessionService {
             }
         }
 
-        // 목표 시간(임시 60분) 기반 남은 시간 계산
-        long targetMinutes = 60L;   // 이 부분 사용자가 실제로 설정한 시간으로 받아와야됨. FocusTimerSetting 부분
+        long targetMinutes = focusSetting.getTimerMinutes();
         long remainingMinutes = Math.max(0, targetMinutes - totalReadMinutes);
 
         // 4. 공통 반환 필드 세팅 (status에 실제 DB 상태값 반영)
         ReadingSessionResponse.IncompleteResult.IncompleteResultBuilder builder =
                 ReadingSessionResponse.IncompleteResult.builder()
                         .sessionId(session.getId())
-                        .status(session.getStatus().name()) // 오타 수정: 실제 상태값 반환
+                        .status(session.getStatus().name())
                         .totalReadMinutes(totalReadMinutes)
                         .focusBlockEnabled(focusSetting.getFocusBlockEnabled())
                         .whiteNoiseEnabled(focusSetting.getWhiteNoiseEnabled());

--- a/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/service/ReadingSessionSettingsServiceImpl.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
+@Transactional(readOnly = false)
 public class ReadingSessionSettingsServiceImpl implements ReadingSessionSettingsService {
 
     private final FocusModeRepository focusModeRepository;
@@ -152,5 +152,13 @@ public class ReadingSessionSettingsServiceImpl implements ReadingSessionSettings
                 .focusBlockEnabled(setting.getFocusBlockEnabled())
                 .whiteNoiseEnabled(setting.getWhiteNoiseEnabled())
                 .build();
+    }
+
+    public void updateSessionSettings(Long memberId, Long time) {
+        FocusTimerSetting setting = getOrCreateSetting(memberId);
+
+        setting.updateTimerMinutes(time);
+
+        focusModeRepository.save(setting);
     }
 }

--- a/src/main/java/whoreads/backend/global/exception/ErrorCode.java
+++ b/src/main/java/whoreads/backend/global/exception/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     // Reading Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "독서 세션을 찾을 수 없습니다."),
     SESSION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "이미 진행 중인 독서 세션이 있습니다."),
+    INCOMPLETE_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "미완료 독서 세션을 찾을 수 없습니다."),
 
     // Focus Mode
     FOCUS_MODE_NOT_FOUND(HttpStatus.NOT_FOUND, "집중 모드 설정을 찾을 수 없습니다."),


### PR DESCRIPTION
## 📝 작업 요약
- 미완료 독서 세션 조회 API 생성 및 스케줄러 에러 수정

## 🔗 관련 이슈(있으면)
- #153 

## 🛠 주요 변경 사항
- 미완료 독서 세션 조회 API 생성 및 문서화
- 중복 세션 발생 시 500 에러 발생 문제 때문에 메서드 수정 (`ReadingSessionRepository`)
- 세션 `heartbeat` 정상 동작 확인을 위한 로깅 추가 (`ReadingSessionScheduler`)
- 장기 미응답(Stale) 세션 판단 기준 시간 단축 (5시간 -> 2시간) (PR이랑 피그마 보고 수정)
  (https://github.com/WhoReads-umc-9th/whoreads-backend/pull/152)
- `heartbeat`에 의해서 세션 자동 처리 시 `COMPLETED` -> `SUSPENDED` 상태로 수정

## 🔍 리뷰 포인트
- 요구 사항과 다르거나 잘못 수정한게 있는지 봐주세요

## 📸 테스트 결과 (선택 사항)
### 미완료 독서 세션이 없을 때 에러 메시지
<img width="383" height="118" alt="image" src="https://github.com/user-attachments/assets/ca335397-f0dd-46f6-9166-5b979df01c9f" />

### 세션 진행중
<img width="287" height="251" alt="image" src="https://github.com/user-attachments/assets/a5df8657-75bb-40bb-95b6-d54a711760a8" />

### 세션 일시정지
<img width="271" height="254" alt="image" src="https://github.com/user-attachments/assets/6f2987f8-ec5d-4bd8-ad6d-d6514c8275e3" />

### 세션 재개 후 heartbeat
<img width="382" height="138" alt="image" src="https://github.com/user-attachments/assets/8523ee56-d797-464a-b3db-44f3b6441951" /> <br><br>


**테스트를 위해서 `threshold` 시간은 1분으로 설정**


``` java
@Slf4j
@Service
@RequiredArgsConstructor
public class ReadingSessionScheduler {

    private final ReadingSessionRepository readingSessionRepository;

    @Transactional
    @Scheduled(fixedDelay = 60_000, zone = "Asia/Seoul")
    public void expireStaleSessions() {
        LocalDateTime threshold = LocalDateTime.now().minusMinutes(1);
        List<ReadingSession> staleSessions = readingSessionRepository.findStaleInProgressSessions(threshold);
        ...
        ...
        log.info("[ReadingSessionScheduler] stale 세션 {}건 자동 완료 처리", staleSessions.size());
    }
}
```

### 정상 동작하는 로그
<img width="528" height="14" alt="image" src="https://github.com/user-attachments/assets/f229d74d-d488-49d8-9eb2-939d7648cfd1" />

### 정상적으로 바뀌는 세션 상태
<img width="271" height="254" alt="image" src="https://github.com/user-attachments/assets/c340e949-0f08-43f7-b10b-7db373659052" />




## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting1
### 1. 문제 상황
`/incomplete` (미완료 세션 조회) API 호출 시 500 에러 발생

**에러 로그**
``` java
org.springframework.dao.IncorrectResultSizeDataAccessException: Query did not return a unique result: 3 results were returned
Caused by: org.hibernate.NonUniqueResultException: Query did not return a unique result: 3 results were returned
```

### 2. 원인 분석
``` java
Optional<ReadingSession> findByMemberIdAndStatusIn(Long memberId, List<SessionStatus> statuses);
```
이 코드는 사용자의 세션 중에 상태가 `IN_PROGRESS`, `PAUSED`, `SUSPENDED` 중 1개(Optional)만 찾아준다

하지만 앱이 비정상적으로 종료되면 정상적으로 종료되지 않은 여러 세션이 누적되기 때문에 문제가 생긴다.

결과적으로 DB에서 정상적으로 종료되지 않은 여러 개의 결과가 반환되었으나 코드는 하나의 결과

만 기대했기 때문에 사이즈 불일치(`NonUniqueResultException`) 에러를 던진다.


### 3. 해결 방법
사용자의 최근 세션을 가져오도록 변경하여 해당 버그로 부터 보호한다.
```java
Optional<ReadingSession> findFirstByMemberIdAndStatusInOrderByCreatedAtDesc(Long memberId, List<SessionStatus> statuses);
```

## 🛠 Troubleshooting2
### 발생한 문제
스케줄러(ReadingSessionScheduler)가 장기 미응답 독서 세션을 주기적으로 검사하여 세션의 상태를 강제로 변경하는 로직을 테스트하는 도중 에러가 발생하며 스케줄러 작업이 중단됨

**에러 로그**
``` java
WARN 19048 --- [whoreads] [  scheduling-1] org.hibernate.orm.jdbc.error : HHH000247: ErrorCode: 1265, SQLState: 01000
WARN 19048 --- [whoreads] [  scheduling-1] org.hibernate.orm.jdbc.error : Data truncated for column 'status' at row 1
ERROR 19048 --- [whoreads] [  scheduling-1] o.s.s.s.TaskUtils$LoggingErrorHandler : Unexpected error occurred in scheduled task

org.springframework.orm.jpa.JpaSystemException: could not execute statement [Data truncated for column 'status' at row 1]
Caused by: java.sql.SQLException: Data truncated for column 'status' at row 1
```

### 문제 상황
- 방치된 세션을 처리하는 스케줄러 로직에서 상태 변경 처리 메서드를 기존 `session.complete()`에서 `session.suspend()`로 수정함
- 사용자가 세션을 시작한 뒤 스케줄러가 해당 세션을 `SUSPENDED` 상태로 DB에 업데이트 하려는 순간 에러 발생
- 특이사항: 이전에 `COMPLETED` 상태로 변경하도록 테스트했을 때는 에러 없이 정상적으로 DB에 저장되었음

### 원인 분석
- **`Data truncated for column 'status'` 에러의 의미:** DB 컬럼에 데이터를 넣으려고 했으나 DB가 삽입을 거부했다는 뜻.
- `COMPLETED`는 성공했으나 `SUSPENDED`에서만 에러가 난 것으로 보아 JPA 엔티티에는 `SUSPENDED` 상태가 존재하지만 실제 MySQL 데이터베이스의 `reading_session` 테이블 내 `status` 컬럼의 허용 목록(ENUM)에 `SUSPENDED` 값이 등록되어 있지 않았기 때문에 발생한 문제
<img width="499" height="146" alt="image" src="https://github.com/user-attachments/assets/944f35cb-1a27-4de7-bd67-f5f7b4f8a67c" />


### 해결 방법
데이터베이스의 `reading_session` 테이블의 status 컬럼에 SUSPENDED 추가
``` sql
ALTER TABLE reading_session
MODIFY COLUMN status ENUM('IN_PROGRESS', 'PAUSED', 'COMPLETED', 'SUSPENDED');
```

`application.yml` 파일에서 아래 부분은 왜 동작하지 않았을까?
``` java
spring:
  jpa:
    hibernate:
      ddl-auto: update
```
기존 ENUM 목록에 새로운 값 추가하기는 못한다고 한다


## 🛠 Troubleshooting3
### 문제 상황
세션 시작→중지→재개 후 **하트비트를 다시 호출하지 않은 상태에서** 스케줄러가 동작할 때 예외 발생
사용자가 독서 타이머를 재개한 후 앱을 불안전하게 종료했을 때 백그라운드 스케줄러가 이를 방치된 세션으로 간주하고 강제 종료를 시도하는 과정에서 에러가 발생하며 스케줄러가 중단됨

**에러 로그**
<img width="528" height="99" alt="image" src="https://github.com/user-attachments/assets/a3c9c12f-19dd-4169-9dbd-a726dab79108" />

### 원인 분석

**1. 마지막으로 `heartbeat`를 호출한 시간을 14시 00분이라고 가정합니다. (**`lastHeartbeatAt = 14:00`)

**2. 일시정지 후 재개 (예: 14:20)**

- 사용자가 잠시 쉬었다가 14시 20분에 **재개** 버튼을 누릅니다.
- 이때 새로운 인터벌이 생깁니다. `새 인터벌 시작 시간 = 14:20`
- 재개하자마자 바로 하트비트를 호출하지 않았기 때문에 서버가 기억하는 **마지막 하트비트 시간은 14시 00분**

**3. 스케줄러 출동 (예: 14:21)**

- 현재 테스트 기준 스케줄러는 1분 마다 돌기 때문에 **14시 21분**에 나타납니다.
- 해당 세션의 마지막 하트비트가 **`14:00`** 인데 스케줄러가 정한 기준(14시 20분)보다 이전이기 때문에 스케줄러는 세션을 강제로 종료시킵니다.

**4. 에러 발생의 순간**

- 스케줄러는 현재 인터벌을 종료하면서 종료 시간은 마지막으로 살아있던 시간인 `14:00`으로 설정하려는데 `ReadingInterval` 은 인터벌은 아까 `14:20`에 시작했기 때문에  `14:00`에 끝날 수 없다는 에러는 발생시킵니다. (`IllegalArgumentException`)

### 에러 발생 코드
- **조건:** 상태가 `IN_PROGRESS` 이면서 마지막 하트비트 시간(`lastHeartbeatAt`)이 현재 시간보다 과거인 세션.
``` java
@Query("SELECT rs FROM ReadingSession rs JOIN FETCH rs.intervals " +
	      "WHERE rs.status = 'IN_PROGRESS' AND rs.lastHeartbeatAt < :threshold")
List<ReadingSession> findStaleInProgressSessions(@Param("threshold") LocalDateTime threshold);
```

### 해결 방법
스케줄러가 인터벌을 종료할 때 현재 인터벌의 시작 시간과 비교하여 보정해 주는 로직 추가
``` java
// ReadingSessionScheduler.java 내부
for (ReadingSession session : staleSessions) {
    session.getIntervals().stream()
            .filter(interval -> interval.getEndTime() == null)
            .findFirst()
            .ifPresent(interval -> {
                LocalDateTime endTime = session.getLastHeartbeatAt();

                // 하트비트가 없거나 인터벌 시작 시간보다 미래가 아닌 경우
                if (endTime == null || !endTime.isAfter(interval.getStartTime())) {
                    // 에러가 발생하지 않도록 시작 시간보다 1초 설정 (0분 독서 처리)
                    endTime = interval.getStartTime().plusSeconds(1);
                }

                // 안전하게 검증된 시간으로 종료
                interval.end(endTime);
            });
            
    session.suspend();
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 진행 중인 독서 세션 상태 조회 API 추가 (남은 시간, 총 독서 시간, 유휴 시간, 포커스 블록 설정 상태 포함)

* **Improvements**
  * 오래된 세션의 자동 중단 감지 시간 최적화 (5시간 → 2시간)
  * 세션 상태 전환 로직 개선으로 더 정확한 시간 기록 보장

<!-- end of auto-generated comment: release notes by coderabbit.ai -->