### PR TITLE
fix: Swagger snake_case 불일치 수정 - 전체 DTO @JsonProperty 추가

### DIFF
--- a/src/main/java/whoreads/backend/auth/dto/AuthReqDto.java
+++ b/src/main/java/whoreads/backend/auth/dto/AuthReqDto.java
@@ -1,5 +1,6 @@
 package whoreads.backend.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
@@ -25,6 +26,7 @@ public class AuthReqDto {
 
     // 아이디 중복 확인 요청
     public record CheckIdRequest(
+            @JsonProperty("login_id")
             @Schema(description = "중복 확인할 아이디", example = "woody123")
             @NotBlank String loginId
     ){}
@@ -32,11 +34,12 @@ public class AuthReqDto {
     // JSON 최상위 {} 역할
     public record SignUpRequest(
             @Valid JoinRequest request,
-            @Valid MemberInfo memberInfo
+            @JsonProperty("member_info") @Valid MemberInfo memberInfo
     ) {}
 
     // 회원가입시 사용
     public record JoinRequest(
+            @JsonProperty("login_id")
             @Schema(description = "로그인 아이디", example = "woody123")
             @NotBlank
             String loginId,
@@ -54,6 +57,7 @@ public class AuthReqDto {
     ){}
 
     public record LoginRequest(
+            @JsonProperty("login_id")
             @Schema(description = "로그인 아이디", example = "woody123")
             @NotBlank String loginId,
             @Schema(description = "비밀번호", example = "password1234!")
@@ -61,6 +65,7 @@ public class AuthReqDto {
     ){}
 
     public record RefreshRequest(
+        @JsonProperty("refresh_token")
         @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ...")
         @NotBlank
         String refreshToken
@@ -71,6 +76,7 @@ public class AuthReqDto {
             String nickname,
             @NotNull
             Gender gender,
+            @JsonProperty("age_group")
             @NotNull
             AgeGroup ageGroup
     ){}

--- a/src/main/java/whoreads/backend/auth/dto/AuthResDto.java
+++ b/src/main/java/whoreads/backend/auth/dto/AuthResDto.java
@@ -1,5 +1,6 @@
 package whoreads.backend.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -8,24 +9,24 @@ public class AuthResDto {
 
     @Builder
     public record JoinData(
-            String accessToken,
+            @JsonProperty("access_token") String accessToken,
             MemberInfo member
     ){}
 
     @Builder
     public record MemberInfo(
             Long id,
-            String loginId,
+            @JsonProperty("login_id") String loginId,
             String email,
-            LocalDateTime createdAt
+            @JsonProperty("created_at") LocalDateTime createdAt
     ){}
 
     @Builder
     public record TokenData(
-            Long memberId,
-            String grantType,
-            String accessToken,
-            String refreshToken,
-            Long accessTokenExpiresIn
+            @JsonProperty("member_id") Long memberId,
+            @JsonProperty("grant_type") String grantType,
+            @JsonProperty("access_token") String accessToken,
+            @JsonProperty("refresh_token") String refreshToken,
+            @JsonProperty("access_token_expires_in") Long accessTokenExpiresIn
     ){}
 }

--- a/src/main/java/whoreads/backend/domain/book/dto/BookDetailResponse.java
+++ b/src/main/java/whoreads/backend/domain/book/dto/BookDetailResponse.java
@@ -1,6 +1,7 @@
 package whoreads.backend.domain.book.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,21 +26,21 @@ public class BookDetailResponse {
 
     private Long id;
     private String title;
-    private String authorName;
+    @JsonProperty("author_name") private String authorName;
     private String genre;
-    private String coverUrl;
+    @JsonProperty("cover_url") private String coverUrl;
     private String link;
-    private int quoteCount;
+    @JsonProperty("quote_count") private int quoteCount;
     @Setter
-    private ReadingInfo readingInfo;  // 담아둔 책이 아니면 null
+    @JsonProperty("reading_info") private ReadingInfo readingInfo;
     private List<QuoteDetail> quotes;
 
     @Getter
     @Builder
     public static class QuoteDetail {
-        private Long quoteId;
-        private String originalText;
-        private int contextScore;
+        @JsonProperty("quote_id") private Long quoteId;
+        @JsonProperty("original_text") private String originalText;
+        @JsonProperty("context_score") private int contextScore;
         private CelebrityInfo celebrity;
         private QuoteResponse.SourceInfo source;
     }
@@ -49,8 +50,8 @@ public class BookDetailResponse {
     public static class CelebrityInfo {
         private Long id;
         private String name;
-        private String imageUrl;
-        private List<String> jobTags;
+        @JsonProperty("image_url") private String imageUrl;
+        @JsonProperty("job_tags") private List<String> jobTags;
 
         public static CelebrityInfo from(Celebrity celebrity) {
             return CelebrityInfo.builder()
@@ -68,11 +69,11 @@ public class BookDetailResponse {
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ReadingInfo {
-        private ReadingStatus readingStatus;
-        private Integer readingPage;
-        private Integer totalPage;
-        private LocalDate startedAt;
-        private LocalDate completedAt;
+        @JsonProperty("reading_status") private ReadingStatus readingStatus;
+        @JsonProperty("reading_page") private Integer readingPage;
+        @JsonProperty("total_page") private Integer totalPage;
+        @JsonProperty("started_at") private LocalDate startedAt;
+        @JsonProperty("completed_at") private LocalDate completedAt;
 
         public static ReadingInfo from(UserBook userBook, Book book) {
             return ReadingInfo.builder()

--- a/src/main/java/whoreads/backend/domain/book/dto/BookRequest.java
+++ b/src/main/java/whoreads/backend/domain/book/dto/BookRequest.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.book.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
@@ -13,28 +14,30 @@ import whoreads.backend.domain.book.entity.Book;
 public class BookRequest {
 
     @NotBlank(message = "제목은 필수입니다.")
-    @Size(max = 255, message = "제목은 255자 이내여야 합니다.") // 바꾼 이유: DB 컬럼 사이즈 초과 시 발생하는 500 에러를 막기 위해 길이 제한 추가
+    @Size(max = 255, message = "제목은 255자 이내여야 합니다.")
     private String title;
 
+    @JsonProperty("author_name")
     @NotBlank(message = "작가 이름은 필수입니다.")
-    @Size(max = 100, message = "작가 이름은 100자 이내여야 합니다.") // 바꾼 이유: 길이 제한 추가
+    @Size(max = 100, message = "작가 이름은 100자 이내여야 합니다.")
     private String authorName;
 
-    @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 이상한 문자열이 링크로 들어오는 것을 방지
+    @JsonProperty("cover_url")
+    @URL(message = "올바른 URL 형식이어야 합니다.")
     private String coverUrl;
 
-    @URL(message = "올바른 URL 형식이어야 합니다.") // 바꾼 이유: 올바른 URL 형식 확인
+    @URL(message = "올바른 URL 형식이어야 합니다.")
     private String link;
 
     private String genre;
 
-    @Positive(message = "총 페이지 수는 0보다 커야 합니다.") // 바꾼 이유: 총 페이지 수가 0이거나 음수인 논리적 오류 차단
+    @JsonProperty("total_page")
+    @Positive(message = "총 페이지 수는 0보다 커야 합니다.")
     private Integer totalPage;
 
-    // DTO -> Entity 변환 메서드
     public Book toEntity() {
         return Book.builder()
-                .title(title.trim()) // 바꾼 이유: 앞뒤 공백으로 인한 중복 데이터 생성 방지
+                .title(title.trim())
                 .authorName(authorName.trim())
                 .coverUrl(coverUrl)
                 .link(link)

--- a/src/main/java/whoreads/backend/domain/book/dto/BookResponse.java
+++ b/src/main/java/whoreads/backend/domain/book/dto/BookResponse.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.book.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.book.entity.Book;
@@ -9,10 +10,10 @@ import whoreads.backend.domain.book.entity.Book;
 public class BookResponse {
     private Long id;
     private String title;
-    private String authorName;
+    @JsonProperty("author_name") private String authorName;
     private String genre;
-    private String coverUrl;
-    private Integer totalPage;
+    @JsonProperty("cover_url") private String coverUrl;
+    @JsonProperty("total_page") private Integer totalPage;
 
     public static BookResponse from(Book book) {
         return BookResponse.builder()

--- a/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityResponse.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityResponse.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.celebrity.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.celebrity.entity.Celebrity;
@@ -13,9 +14,9 @@ import java.util.stream.Collectors;
 public class CelebrityResponse {
     private Long id;
     private String name;
-    private String imageUrl;
-    private String shortBio;    // 한줄 소개
-    private List<String> jobTags;
+    @JsonProperty("image_url") private String imageUrl;
+    @JsonProperty("short_bio") private String shortBio;
+    @JsonProperty("job_tags") private List<String> jobTags;
 
     public static CelebrityResponse from(Celebrity celebrity) {
         return CelebrityResponse.builder()

--- a/src/main/java/whoreads/backend/domain/dna/converter/DnaConverter.java
+++ b/src/main/java/whoreads/backend/domain/dna/converter/DnaConverter.java
@@ -64,7 +64,7 @@ public class DnaConverter {
             jobTags.add(tag.getDescription());
 
         return DnaResDto.Result.builder()
-                .resultHeaLine(String.format("지금 당신은 '%s'를 위해 독서를 하는 사람입니다.", headLine))
+                .resultHeadLine(String.format("지금 당신은 '%s'를 위해 독서를 하는 사람입니다.", headLine))
                 .description(descriptionList)
                 .celebrityId(celebrity.getId())
                 .celebrityName(celebrity.getName())

--- a/src/main/java/whoreads/backend/domain/dna/dto/DnaReqDto.java
+++ b/src/main/java/whoreads/backend/domain/dna/dto/DnaReqDto.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.dna.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Size;
 import whoreads.backend.domain.dna.enums.TrackCode;
@@ -9,11 +10,11 @@ import java.util.List;
 public class DnaReqDto {
 
     public record Submit(
-            // Q1에서 선택한 독서 목적
+            @JsonProperty("track_code")
             @Schema(example = "COMFORT")
             TrackCode trackCode,
 
-            // Q2~Q5에서 선택한 보기(DnaOption)의 ID 리스트(장르 점수 합산)
+            @JsonProperty("selected_option_ids")
             @Size(min = 4, max = 4, message = "Q2부터 Q5까지 총 4개의 답변이 필요합니다.")
             @Schema(example = "[6, 10, 14, 18]")
             List<Long> selectedOptionIds

--- a/src/main/java/whoreads/backend/domain/dna/dto/DnaResDto.java
+++ b/src/main/java/whoreads/backend/domain/dna/dto/DnaResDto.java
@@ -37,7 +37,7 @@ public class DnaResDto {
 
     @Builder
     public record Result(
-            @JsonProperty("result_hea_line") String resultHeaLine,
+            @JsonProperty("result_headline") String resultHeadLine,
             List<String> description,
             @JsonProperty("celebrity_id") Long celebrityId,
             @JsonProperty("celebrity_name") String celebrityName,

--- a/src/main/java/whoreads/backend/domain/dna/dto/DnaResDto.java
+++ b/src/main/java/whoreads/backend/domain/dna/dto/DnaResDto.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.dna.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import whoreads.backend.domain.dna.enums.TrackCode;
 
@@ -7,66 +8,40 @@ import java.util.List;
 
 public class DnaResDto {
 
-    // Q1 질문 및 보기
     @Builder
     public record Question(
             Long id,
             int step,
             String content,
             List<Option> options
-            // Q1 질문 예시
-            // content: "사용자는 독서를 통해 어떤 종류의 도움을 가장 필요로 하는가?"
-            // options: "마음정리/위로", "실행력/습관", ...
     ){}
 
-    // Q1 ~ Q5 보기
     @Builder
     public record Option(
             Long id,
             String content,
-            // 보기를 선택했을 때 진입하게 될 트랙 식별자
-            /*
-                COMFORT("마음 정리/위로"),
-                HABIT("실행력/습관"),
-                CAREER("커리어/시야 넓히기"),
-                INSIGHT("사고 확장/관점"),
-                FOCUS("재미/몰입");
-             */
-            TrackCode trackCode
+            @JsonProperty("track_code") TrackCode trackCode
     ){}
 
-
-    // 첫 테스트에서 확정된 트랙에 대한 "질문"
     @Builder
     public record TrackQuestion(
-            TrackCode trackCode,
-            // 해당 트랙의 Q2~Q5
-            // 여기 안에는 보기도 포함되어 있다.
-            // 변수명 바꿔야 할듯
+            @JsonProperty("track_code") TrackCode trackCode,
             List<Question> questions
     ){}
 
-    // 첫 테스트에서 확정된 트랙에 대한 "보기"
     @Builder
     public record TrackOptions(
-            Long questionId,
+            @JsonProperty("question_id") Long questionId,
             List<Option> options
     ){}
 
-    // 테스트 최종 결과 전송
     @Builder
     public record Result(
-            String resultHeaLine,  // "지금 당신은 000을 위해 독서를 하는 사람입니다."
-            List<String> description, // 이거 배열에 문장별로 나눠서 넘겨줘야됨
-            Long celebrityId,
-            String celebrityName,
-            String imageUrl,
-            List<String> jobTags
-
-
-            // 추가해야할 것
-            // 000의 추천 도서 확인하기
-            // 눌렀을 때 해당 인물 탭으로 이동하는데
-            // 인물 도메인에서 만든거 여기로 가져오면 될듯
+            @JsonProperty("result_hea_line") String resultHeaLine,
+            List<String> description,
+            @JsonProperty("celebrity_id") Long celebrityId,
+            @JsonProperty("celebrity_name") String celebrityName,
+            @JsonProperty("image_url") String imageUrl,
+            @JsonProperty("job_tags") List<String> jobTags
     ){}
 }

--- a/src/main/java/whoreads/backend/domain/library/dto/UserBookRequest.java
+++ b/src/main/java/whoreads/backend/domain/library/dto/UserBookRequest.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import whoreads.backend.domain.library.enums.ReadingStatus;
 
@@ -7,7 +8,9 @@ public class UserBookRequest {
 
     @Getter
     public static class UpdateStatus {
+        @JsonProperty("reading_status")
         private ReadingStatus readingStatus;
+        @JsonProperty("reading_page")
         private Integer readingPage;
     }
 }

--- a/src/main/java/whoreads/backend/domain/library/dto/UserBookResponse.java
+++ b/src/main/java/whoreads/backend/domain/library/dto/UserBookResponse.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.library.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.book.dto.BookResponse;
@@ -12,31 +13,31 @@ public class UserBookResponse {
     @Getter
     @Builder
     public static class Summary {
-        private Integer completedCount;
-        private Integer readingCount;
-        private Long totalReadMinutes;
+        @JsonProperty("completed_count") private Integer completedCount;
+        @JsonProperty("reading_count") private Integer readingCount;
+        @JsonProperty("total_read_minutes") private Long totalReadMinutes;
     }
 
     @Getter
     @Builder
     public static class AddResult {
-        private Long userBookId;
+        @JsonProperty("user_book_id") private Long userBookId;
     }
 
     @Getter
     @Builder
     public static class CelebritySummary {
         private Long id;
-        private String profileUrl;
+        @JsonProperty("profile_url") private String profileUrl;
     }
 
     @Getter
     @Builder
     public static class SimpleBook {
-        private Long userBookId;
+        @JsonProperty("user_book_id") private Long userBookId;
         private BookResponse book;
-        private Integer readingPage;
-        private Integer celebritiesCount;
+        @JsonProperty("reading_page") private Integer readingPage;
+        @JsonProperty("celebrities_count") private Integer celebritiesCount;
         private List<CelebritySummary> celebrities;
 
         public static SimpleBook from(UserBook userBook, List<CelebritySummary> celebrities) {
@@ -54,8 +55,7 @@ public class UserBookResponse {
     @Builder
     public static class BookList {
         private List<SimpleBook> books;
-        private Long nextCursor;
-        private Boolean hasNext;
+        @JsonProperty("next_cursor") private Long nextCursor;
+        @JsonProperty("has_next") private Boolean hasNext;
     }
-
 }

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -1,9 +1,11 @@
 package whoreads.backend.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public class MemberRequest {
     public record FcmTokenRequest(
+            @JsonProperty("fcm_token")
             @NotBlank
             String fcmToken
     ){}

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberResDto.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberResDto.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.member.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import whoreads.backend.domain.dna.enums.TrackCode;
 import whoreads.backend.domain.member.enums.AgeGroup;
@@ -15,22 +16,22 @@ public class MemberResDto {
             Long id,
             String nickname,
             Gender gender,
-            AgeGroup ageGroup,
+            @JsonProperty("age_group") AgeGroup ageGroup,
             String email,
-            String loginId,
-            LocalDateTime createdAt,
-            LocalDateTime updatedAt,
-            LocalDateTime deletedAt,
+            @JsonProperty("login_id") String loginId,
+            @JsonProperty("created_at") LocalDateTime createdAt,
+            @JsonProperty("updated_at") LocalDateTime updatedAt,
+            @JsonProperty("deleted_at") LocalDateTime deletedAt,
             Status status,
-            TrackCode trackCode,
-            String fcmToken
+            @JsonProperty("track_code") TrackCode trackCode,
+            @JsonProperty("fcm_token") String fcmToken
     ){}
 
     @Builder
     public record CelebrityFollow(
             Long id,
             String name,
-            String imageUrl,
-            String shortBio
+            @JsonProperty("image_url") String imageUrl,
+            @JsonProperty("short_bio") String shortBio
     ) {}
 }

--- a/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.notification.enums.NotificationType;
@@ -12,21 +13,18 @@ import java.util.Map;
 public class FcmMessageDTO {
     private final String title;
     private final String body;
-    private final Long celebrityId;
-    private final Long bookId;
+    @JsonProperty("celebrity_id") private final Long celebrityId;
+    @JsonProperty("book_id") private final Long bookId;
     private final String type;
     private final Map<String, String> data;
 
-    /*
-    todo: 링크 처리하는 것 정하기!
-    * */
     public static FcmMessageDTO of(NotificationType type, NotificationEvent event) {
         String[] generated = type.generateMessage(event);
 
         FcmMessageDTO.FcmMessageDTOBuilder builder = FcmMessageDTO.builder()
                 .title(generated[0])
                 .body(generated[1])
-                .type(type.name()); // DB 저장용 타입 이름 (FOLLOW, ROUTINE 등)
+                .type(type.name());
 
         if (event != null && type == NotificationType.FOLLOW &&
                 event instanceof NotificationEvent.FollowEvent followEvent)

--- a/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/FcmMessageDTO.java
@@ -1,6 +1,5 @@
 package whoreads.backend.domain.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.notification.enums.NotificationType;
@@ -13,8 +12,8 @@ import java.util.Map;
 public class FcmMessageDTO {
     private final String title;
     private final String body;
-    @JsonProperty("celebrity_id") private final Long celebrityId;
-    @JsonProperty("book_id") private final Long bookId;
+    private final Long celebrityId;
+    private final Long bookId;
     private final String type;
     private final Map<String, String> data;
 

--- a/src/main/java/whoreads/backend/domain/notification/dto/NotificationReqDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/NotificationReqDTO.java
@@ -1,6 +1,7 @@
 package whoreads.backend.domain.notification.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
@@ -22,11 +23,11 @@ public class NotificationReqDTO {
             @NotNull(message = "알림 타입은 필수 입력 값입니다.")
             NotificationType type,
 
+            @JsonProperty("is_enabled")
             boolean isEnabled,
 
             List<DayOfWeek> days
     ) {
-        //type에 따라 검사
         public void validate() {
             if (this.type == NotificationType.ROUTINE) {
                 if (this.time == null) throw new CustomException(ErrorCode.INVALID_INPUT_VALUE,"루틴 알림은 시간이 필수입니다.");

--- a/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
+++ b/src/main/java/whoreads/backend/domain/notification/dto/NotificationResDTO.java
@@ -1,8 +1,8 @@
 package whoreads.backend.domain.notification.dto;
 
-
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import whoreads.backend.domain.notification.entity.FollowLink;
@@ -12,15 +12,15 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
-// NULL 인 필드 보내지 않기
 public class NotificationResDTO {
-    // 알림 설정 리스트 조회
+
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record TotalSettingDTO(
-            SettingDTO followSetting,
-            List<SettingDTO> routineSettings
+            @JsonProperty("follow_setting") SettingDTO followSetting,
+            @JsonProperty("routine_settings") List<SettingDTO> routineSettings
     ){}
+
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record SettingDTO(
@@ -30,16 +30,17 @@ public class NotificationResDTO {
             String type,
             LocalTime time,
             List<DayOfWeek> days,
-            boolean isEnabled
+            @JsonProperty("is_enabled") boolean isEnabled
     ){}
-    // 알림내역 조회
+
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record TotalInboxDTO(
             List<HistoryDTO> contents,
-            Long nextCursor,
-            Boolean hasNext
+            @JsonProperty("next_cursor") Long nextCursor,
+            @JsonProperty("has_next") Boolean hasNext
     ){}
+
     @Builder
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record HistoryDTO(
@@ -48,7 +49,8 @@ public class NotificationResDTO {
             String title,
             String body,
             FollowLink link,
-            boolean isRead,
+            @JsonProperty("is_read") boolean isRead,
+            @JsonProperty("created_at")
             @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
             LocalDateTime createdAt
     ){}

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteRequest.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.quote.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -16,15 +17,17 @@ import whoreads.backend.domain.quote.entity.QuoteSourceType;
 @NoArgsConstructor
 public class QuoteRequest {
 
-    // 1. 기본 정보
+    @JsonProperty("book_id")
     @NotNull(message = "책 ID는 필수입니다.")
     @Positive(message = "책 ID는 양수여야 합니다.")
     private Long bookId;
 
+    @JsonProperty("celebrity_id")
     @NotNull(message = "유명인 ID는 필수입니다.")
     @Positive(message = "유명인 ID는 양수여야 합니다.")
     private Long celebrityId;
 
+    @JsonProperty("original_text")
     @NotBlank(message = "인용 문구는 필수입니다.")
     @Size(max = 2000, message = "인용 문구는 2000자를 초과할 수 없습니다.")
     private String originalText;
@@ -32,17 +35,15 @@ public class QuoteRequest {
     @NotNull(message = "언어 설정은 필수입니다.")
     private Quote.Language language;
 
-    // 바꾼 이유: primitive int는 누락 시 0으로 바인딩되어 검증을 우회하므로 Integer + @NotNull로 변경
+    @JsonProperty("context_score")
     @NotNull(message = "맥락 점수는 필수입니다.")
     @Min(value = 0, message = "맥락 점수는 0 이상이어야 합니다.")
     private Integer contextScore;
 
-    // 2. 출처 정보 (선택)
-    @Valid // 바꾼 이유: 중첩된 객체(SourceInfo) 내부의 필드 검증(@URL 등)을 활성화하기 위해 추가
+    @Valid
     private SourceInfo source;
 
-    // 3. 맥락 정보 (선택)
-    @Valid // 누락되었던 검증 활성화
+    @Valid
     private ContextInfo context;
 
     @Getter
@@ -52,7 +53,7 @@ public class QuoteRequest {
         private String url;
         private QuoteSourceType type;
         private String timestamp;
-        private boolean isDirect; // 직접 인용 여부 (true: 직접, false: 간접/추천사 아님 등)
+        @JsonProperty("is_direct") private boolean isDirect;
     }
 
     @Getter
@@ -60,13 +61,10 @@ public class QuoteRequest {
     public static class ContextInfo {
         @Size(max = 1000, message = "계기 설명은 1000자 이내여야 합니다.")
         private String how;
-
         @Size(max = 500, message = "시기 설명은 500자 이내여야 합니다.")
         private String when;
-
         @Size(max = 1000, message = "이유 설명은 1000자 이내여야 합니다.")
         private String why;
-
         @Size(max = 1000, message = "도움 설명은 1000자 이내여야 합니다.")
         private String help;
     }

--- a/src/main/java/whoreads/backend/domain/quote/dto/QuoteResponse.java
+++ b/src/main/java/whoreads/backend/domain/quote/dto/QuoteResponse.java
@@ -1,5 +1,6 @@
 package whoreads.backend.domain.quote.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.book.entity.Book;
@@ -13,24 +14,19 @@ import whoreads.backend.domain.quote.entity.QuoteSource;
 public class QuoteResponse {
 
     private Long id;
-    private String originalText;
-    private int contextScore;
+    @JsonProperty("original_text") private String originalText;
+    @JsonProperty("context_score") private int contextScore;
 
-    // 책 정보
-    private Long bookId;
-    private String bookTitle;
-    private String bookCover;
+    @JsonProperty("book_id") private Long bookId;
+    @JsonProperty("book_title") private String bookTitle;
+    @JsonProperty("book_cover") private String bookCover;
 
-    // 인물 정보
-    private Long celebrityId;
-    private String celebrityName;
-    private String celebrityImg;
-    private String celebrityJob;
+    @JsonProperty("celebrity_id") private Long celebrityId;
+    @JsonProperty("celebrity_name") private String celebrityName;
+    @JsonProperty("celebrity_img") private String celebrityImg;
+    @JsonProperty("celebrity_job") private String celebrityJob;
 
-    // 맥락 (Why, How)
     private ContextInfo context;
-
-    // 출처 (Link)
     private SourceInfo source;
 
     @Getter @Builder
@@ -44,7 +40,7 @@ public class QuoteResponse {
     @Getter @Builder
     public static class SourceInfo {
         private String url;
-        private String type; // Enum Name or Description
+        private String type;
         private String timestamp;
     }
 
@@ -53,23 +49,19 @@ public class QuoteResponse {
                 .id(quote.getId())
                 .originalText(quote.getOriginalText())
                 .contextScore(quote.getContextScore())
-                // 책 정보
                 .bookId(book.getId())
                 .bookTitle(book.getTitle())
                 .bookCover(book.getCoverUrl())
-                // 인물 정보
                 .celebrityId(celebrity.getId())
                 .celebrityName(celebrity.getName())
                 .celebrityImg(celebrity.getImageUrl())
                 .celebrityJob(celebrity.getShortBio())
-                // 맥락
                 .context(ctx != null ? ContextInfo.builder()
                         .how(ctx.getContextHow())
                         .when(ctx.getContextWhen())
                         .why(ctx.getContextWhy())
                         .help(ctx.getContextHelp())
                         .build() : null)
-                // 출처 (NPE 방지 처리)
                 .source(src != null ? SourceInfo.builder()
                         .url(src.getSourceUrl())
                         .type(src.getSourceType() != null ? src.getSourceType().name() : null)

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionRequest.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionRequest.java
@@ -1,7 +1,7 @@
 package whoreads.backend.domain.readingsession.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -14,6 +14,7 @@ public class ReadingSessionRequest {
     @Getter
     @NoArgsConstructor
     public static class Start {
+        @JsonProperty("member_id")
         @NotNull(message = "memberId는 필수입니다.")
         private Long memberId;
     }
@@ -21,6 +22,7 @@ public class ReadingSessionRequest {
     @Getter
     @NoArgsConstructor
     public static class UpdateFocusBlock {
+        @JsonProperty("focus_block_enabled")
         @NotNull(message = "focus_block_enabled는 필수입니다.")
         private Boolean focusBlockEnabled;
     }
@@ -28,6 +30,7 @@ public class ReadingSessionRequest {
     @Getter
     @NoArgsConstructor
     public static class UpdateWhiteNoise {
+        @JsonProperty("white_noise_enabled")
         @NotNull(message = "white_noise_enabled는 필수입니다.")
         private Boolean whiteNoiseEnabled;
     }
@@ -35,6 +38,7 @@ public class ReadingSessionRequest {
     @Getter
     @NoArgsConstructor
     public static class UpdateBlockedApps {
+        @JsonProperty("blocked_apps")
         @NotNull(message = "blocked_apps는 필수입니다.")
         @Size(max = 100, message = "차단 앱은 최대 100개까지 등록할 수 있습니다.")
         @Valid

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionRequest.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionRequest.java
@@ -15,7 +15,7 @@ public class ReadingSessionRequest {
     @NoArgsConstructor
     public static class Start {
         @JsonProperty("member_id")
-        @NotNull(message = "memberId는 필수입니다.")
+        @NotNull(message = "member_id는 필수입니다.")
         private Long memberId;
     }
 

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -2,6 +2,7 @@ package whoreads.backend.domain.readingsession.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.readingsession.enums.SessionStatus;
@@ -88,5 +89,18 @@ public class ReadingSessionResponse {
     @Builder
     public static class BlockedApps {
         @JsonProperty("blocked_apps") private List<BlockedAppItem> blockedApps;
+    }
+
+    @Getter
+    @Builder
+    @JsonPropertyOrder({"session_id", "status", "total_read_minutes", "remaining_minutes", "idle_minutes", "focus_block_enabled", "white_noise_enabled"})
+    public static class IncompleteResult {
+        @JsonProperty("session_id") private Long sessionId;
+        private String status;
+        @JsonProperty("total_read_minutes") private Long totalReadMinutes;
+        @JsonProperty("remaining_minutes") private Long remainingMinutes;
+        @JsonProperty("idle_minutes") private Long idleMinutes;
+        @JsonProperty("focus_block_enabled") private Boolean focusBlockEnabled;
+        @JsonProperty("white_noise_enabled") private Boolean whiteNoiseEnabled;
     }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -93,6 +93,14 @@ public class ReadingSessionResponse {
 
     @Getter
     @Builder
+    public static class SessionSettings {
+        @JsonProperty("timer_minutes") private Long timerMinutes;
+        @JsonProperty("focus_block_enabled") private Boolean focusBlockEnabled;
+        @JsonProperty("white_noise_enabled") private Boolean whiteNoiseEnabled;
+    }
+
+    @Getter
+    @Builder
     @JsonPropertyOrder({"session_id", "status", "total_read_minutes", "remaining_minutes", "idle_minutes", "focus_block_enabled", "white_noise_enabled"})
     public static class IncompleteResult {
         @JsonProperty("session_id") private Long sessionId;
@@ -102,36 +110,5 @@ public class ReadingSessionResponse {
         @JsonProperty("idle_minutes") private Long idleMinutes;
         @JsonProperty("focus_block_enabled") private Boolean focusBlockEnabled;
         @JsonProperty("white_noise_enabled") private Boolean whiteNoiseEnabled;
-    }
-
-    @Getter
-    @Builder
-    public static class SessionSettings { // 추가 - 현
-        private Long timerMinutes;
-        private Boolean focusBlockEnabled;
-        private Boolean whiteNoiseEnabled;
-    }
-
-    @Getter
-    @Builder
-    @JsonPropertyOrder({
-            "sessionId",
-            "status",
-            "totalReadMinutes",
-            "remainingMinutes",
-            "idleMinutes",
-            "focusBlockEnabled",
-            "whiteNoiseEnabled"
-    })
-    public static class IncompleteResult {
-        private Long sessionId;
-        private String status;   // IN_PROGRESS, PAUSED, SUSPENDED
-        private Long totalReadMinutes;
-        private Long idleMinutes;   // IN_PROGRESS인 경우 마지막 세션 이후 경과 시간
-        private Long remainingMinutes;
-
-        // 집중 모드 설정 정보
-        private Boolean focusBlockEnabled;
-        private Boolean whiteNoiseEnabled;
     }
 }

--- a/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
+++ b/src/main/java/whoreads/backend/domain/readingsession/dto/ReadingSessionResponse.java
@@ -1,6 +1,7 @@
 package whoreads.backend.domain.readingsession.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 import whoreads.backend.domain.readingsession.enums.SessionStatus;
@@ -14,40 +15,40 @@ public class ReadingSessionResponse {
     @Getter
     @Builder
     public static class StartResult {
-        private Long sessionId;
+        @JsonProperty("session_id") private Long sessionId;
     }
 
     @Getter
     @Builder
     public static class SessionDetail {
-        private Long sessionId;
+        @JsonProperty("session_id") private Long sessionId;
         private SessionStatus status;
-        private Long totalMinutes;
-        private LocalDateTime createdAt;
-        private LocalDateTime finishedAt;
+        @JsonProperty("total_minutes") private Long totalMinutes;
+        @JsonProperty("created_at") private LocalDateTime createdAt;
+        @JsonProperty("finished_at") private LocalDateTime finishedAt;
         private List<IntervalInfo> intervals;
     }
 
     @Getter
     @Builder
     public static class IntervalInfo {
-        private Long intervalId;
-        private LocalDateTime startTime;
-        private LocalDateTime endTime;
-        private Long durationMinutes;
+        @JsonProperty("interval_id") private Long intervalId;
+        @JsonProperty("start_time") private LocalDateTime startTime;
+        @JsonProperty("end_time") private LocalDateTime endTime;
+        @JsonProperty("duration_minutes") private Long durationMinutes;
     }
 
     @Getter
     @Builder
     public static class TodayFocus {
-        private Long todayMinutes;
-        private Long differenceFromYesterday;
+        @JsonProperty("today_minutes") private Long todayMinutes;
+        @JsonProperty("difference_from_yesterday") private Long differenceFromYesterday;
     }
 
     @Getter
     @Builder
     public static class TotalFocus {
-        private Long totalMinutes;
+        @JsonProperty("total_minutes") private Long totalMinutes;
     }
 
     @Getter
@@ -60,23 +61,21 @@ public class ReadingSessionResponse {
     @Builder
     public static class DailyRecord {
         private Integer day;
-        @JsonFormat(pattern = "HH:mm")
-        private LocalTime startTime;
-        @JsonFormat(pattern = "HH:mm")
-        private LocalTime endTime;
-        private Long totalMinutes;
+        @JsonProperty("start_time") @JsonFormat(pattern = "HH:mm") private LocalTime startTime;
+        @JsonProperty("end_time") @JsonFormat(pattern = "HH:mm") private LocalTime endTime;
+        @JsonProperty("total_minutes") private Long totalMinutes;
     }
 
     @Getter
     @Builder
     public static class FocusBlockSetting {
-        private Boolean focusBlockEnabled;
+        @JsonProperty("focus_block_enabled") private Boolean focusBlockEnabled;
     }
 
     @Getter
     @Builder
     public static class WhiteNoiseSetting {
-        private Boolean whiteNoiseEnabled;
+        @JsonProperty("white_noise_enabled") private Boolean whiteNoiseEnabled;
     }
 
     @Getter
@@ -88,6 +87,6 @@ public class ReadingSessionResponse {
     @Getter
     @Builder
     public static class BlockedApps {
-        private List<BlockedAppItem> blockedApps;
+        @JsonProperty("blocked_apps") private List<BlockedAppItem> blockedApps;
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- Spring Boot 4 + Jackson 3 환경에서 Swagger UI가 camelCase 필드명을 표시하여, 서버가 기대하는 snake_case와 불일치하는 버그 수정
- 전체 Request/Response DTO에 `@JsonProperty` 추가로 Swagger 스키마와 실제 API 동작을 일치시킴

## 🔗 관련 이슈(있으면)
- N/A

## 🛠 주요 변경 사항
- [x] Auth, Book, Celebrity, DNA, Library, Member, Notification, Quote, ReadingSession 도메인 전체 DTO `@JsonProperty` 추가
- [x] Swagger Try It Out에서 snake_case로 요청 전송되도록 수정

## 🔍 리뷰 포인트
- **로직**: `@JsonProperty`가 Jackson 2(springdoc 스키마 생성)와 Jackson 3(Spring 요청 역직렬화) 모두에서 인식되는지 확인
- **보안**: N/A

## 📸 테스트 결과 (선택 사항)
- 수정 전: Swagger에서 `loginId`로 전송 → 서버 `must not be blank` 400 에러
- 수정 후: Swagger에서 `login_id`로 표시 및 전송 → 정상 처리

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting
### 1. 문제 현상
- Swagger UI에서 회원가입 등 API를 Try It Out 하면 `must not be blank` 400 에러 발생
- Swagger 스키마는 `loginId`, `memberInfo` (camelCase) 표시 → 서버는 `login_id`, `member_info` (snake_case) 기대

### 2. 원인 분석
Spring Boot 4 업그레이드 이후 Jackson 2(springdoc) ↔ Jackson 3(Spring Boot) 분리로 인한 문제.

**발생 히스토리:**
1. **2026-01-28 (`83ab6f6`)**: Spring Boot 3 시절 `@Primary ObjectMapper(Jackson 2)` + `ModelResolver` 추가 → Swagger snake_case 정상 동작
2. **2026-03-24 (`420935d`)**: `@Primary ObjectMapper` 제거 (JavaTimeModule 등 Spring 자동설정 누락 문제) → `ModelResolver`는 유지, 여전히 정상 동작
3. **2026-04-10 (`0b6251c`, PR #139)**: Spring Boot 3 → 4 업그레이드 시 `ModelResolver` 제거 — "springdoc 3이 Jackson 3 auto-config를 지원한다"는 이유였으나, 실제로는 `swagger-core 2.2.43`이 아직 Jackson 3(`tools.jackson`) 미지원 상태라 Swagger snake_case가 다시 깨짐

**근본 원인:** Spring Boot 4는 Jackson 3(`tools.jackson.databind.ObjectMapper`)을 사용하지만, springdoc은 `swagger-core 2.2.43`(Jackson 2 기반)을 사용. 두 ObjectMapper가 별개로 동작하여 Spring의 SNAKE_CASE 설정이 springdoc 스키마 생성에 반영되지 않음.

`ModelResolver`를 통한 해결은 Jackson 2/3 타입 불일치로 런타임 오류 발생 → `@JsonProperty`로 각 필드에 명시적으로 지정하는 방식으로 해결.

### 3. 해결 방안
전체 DTO 필드에 `@JsonProperty("snake_case_name")` 명시적 추가.
- Jackson 2(springdoc): `@JsonProperty`를 인식하여 스키마에 snake_case 필드명 생성
- Jackson 3(Spring Boot): `@JsonProperty`가 글로벌 SNAKE_CASE 설정보다 우선 적용되어 동일하게 동작

## 💬 한마디
생태계 호환성 확인 없이 Spring Boot 4로 올린 게 이번 작업의 발단이었습니다. 다음엔 메이저 업그레이드 전에 의존성부터 확인하겠습니다 🙏