### PR TITLE
fix: SecurityErrorHandler ObjectMapper 제거로 500 → 401 수정

### DIFF
--- a/src/main/java/whoreads/backend/global/config/SecurityErrorHandler.java
+++ b/src/main/java/whoreads/backend/global/config/SecurityErrorHandler.java
@@ -2,7 +2,6 @@ package whoreads.backend.global.config;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.access.AccessDeniedException;
@@ -10,16 +9,11 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
-import tools.jackson.databind.ObjectMapper;
-import whoreads.backend.global.response.ApiResponse;
 
 import java.io.IOException;
 
 @Component
-@RequiredArgsConstructor
 public class SecurityErrorHandler implements AuthenticationEntryPoint, AccessDeniedHandler {
-
-    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
@@ -39,7 +33,7 @@ public class SecurityErrorHandler implements AuthenticationEntryPoint, AccessDen
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
 
-        ApiResponse<Void> body = ApiResponse.error(status.value(), message);
-        response.getWriter().write(objectMapper.writeValueAsString(body));
+        String body = "{\"is_success\":false,\"code\":" + status.value() + ",\"message\":\"" + message + "\"}";
+        response.getWriter().write(body);
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
Spring Boot 4 마이그레이션으로 인해 인증 오류 응답 시 500이 반환되던 문제 수정

## 🔗 관련 이슈(있으면)
- #151

## 🛠 주요 변경 사항
- [x] `SecurityErrorHandler`에서 `tools.jackson.databind.ObjectMapper` 의존성 제거
- [x] 직접 JSON 문자열 작성 방식으로 교체

## 🔍 리뷰 포인트
- **보안**: Security 필터 체인은 Spring MVC 파이프라인 밖에서 실행됨. Jackson 3.x에서 `JacksonException`이 `RuntimeException`으로 변경되어, `writeValueAsString()` 실패 시 `ExceptionTranslationFilter`를 통해 500으로 전파되던 문제

## 📸 테스트 결과 (선택 사항)
- 인증 없이 보호된 엔드포인트 접근 시 500 → 401 정상 응답 확인

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting
### 1. 문제 현상
- 인증이 필요한 엔드포인트에 토큰 없이 접근 시 401 대신 500 반환

### 2. 원인 분석
- `SecurityErrorHandler`가 `tools.jackson.databind.ObjectMapper`(Jackson 3.x)로 `ApiResponse` 직렬화 시도
- Jackson 3.x에서 `JacksonException`은 `RuntimeException`이므로 `throws IOException`으로 잡히지 않음
- 예외가 `ExceptionTranslationFilter`까지 전파 → 서블릿 컨테이너 → 500

### 3. 해결 방안
- 고정 구조의 에러 응답은 ObjectMapper 불필요 → 직접 JSON 문자열 작성으로 교체
- Jackson 버전 변경에 영향받지 않는 구조로 개선