### PR TITLE
fix: Spring Security 7 SecurityContext 설정 방식 수정으로 401 오류 해결

### DIFF
--- a/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/whoreads/backend/auth/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -35,8 +36,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            // 4. SecurityContext에 인증 정보 설정 (이게 되어야 로그인된 것으로 간주함)
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            SecurityContext context = SecurityContextHolder.createEmptyContext();
+            context.setAuthentication(authentication);
+            SecurityContextHolder.setContext(context);
         }
 
         filterChain.doFilter(request, response);


### PR DESCRIPTION
## 📝 작업 요약
이미 인증된 사용자가 인증 필요 엔드포인트에서 401을 받던 문제 수정

## 🔗 관련 이슈(있으면)
- #151

## 🛠 주요 변경 사항
- [x] `JwtAuthenticationFilter`의 SecurityContext 설정 방식을 Spring Security 7 호환 방식으로 변경

## 🔍 리뷰 포인트
- **인증**: `SecurityContextHolder.getContext().setAuthentication()` → `createEmptyContext()` + `setContext()` 방식으로 변경
- Spring Security 6+ 부터 `SecurityContextHolderFilter`가 컨텍스트 생명주기를 직접 관리하므로, 기존 방식으로는 `AuthorizationFilter` 실행 시점에 인증 정보가 전달되지 않음

## 📸 테스트 결과 (선택 사항)
- 유효한 JWT 토큰으로 인증 필요 엔드포인트(`/api/me/**`, `/api/dna/results` 등) 접근 시 401 → 정상 응답 확인 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting
### 1. 문제 현상
- 로그인 후 인증 토큰을 포함해 요청해도 인증 필요 엔드포인트에서 401 반환

### 2. 원인 분석
- Spring Security 7에서 `SecurityContextHolder.getContext().setAuthentication(auth)` 방식은 새로운 컨텍스트 전파 메커니즘과 맞지 않음
- `AuthorizationFilter` 실행 시점에 SecurityContext가 비어있는 것처럼 동작

### 3. 해결 방안
```java
// 변경 전
SecurityContextHolder.getContext().setAuthentication(authentication);

// 변경 후
SecurityContext context = SecurityContextHolder.createEmptyContext();
context.setAuthentication(authentication);
SecurityContextHolder.setContext(context);
```