### PR TITLE
fix: Hibernate Validator 9 @Valid 불일치 ConstraintDeclarationException 수정

### DIFF
--- a/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/book/controller/docs/BookControllerDocs.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
@@ -35,7 +36,7 @@ public interface BookControllerDocs {
 
     @Operation(summary = "책 등록 (중복 체크)", description = "책 정보를 등록합니다. 만약 제목과 작가가 동일한 책이 이미 있다면, 새로 저장하지 않고 기존 책 정보를 반환합니다.")
     ResponseEntity<BookResponse> registerBook(
-            @RequestBody BookRequest request
+            @RequestBody @Valid BookRequest request
     );
 
     @Operation(summary = "가장 많이 추천된 책 (TOP 20)", description = "유명인들이 가장 많이 언급(인용)한 책들을 추천 수 내림차순으로 조회합니다. limit은 1 이상이어야 합니다.")

--- a/src/main/java/whoreads/backend/domain/quote/controller/docs/QuoteControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/quote/controller/docs/QuoteControllerDocs.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -24,7 +25,7 @@ public interface QuoteControllerDocs {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 책/유명인"),
             @ApiResponse(responseCode = "500", description = "서버 에러")
     })
-    ResponseEntity<Void> registerQuote(@RequestBody QuoteRequest request);
+    ResponseEntity<Void> registerQuote(@RequestBody @Valid QuoteRequest request);
 
     @Operation(summary = "책별 인용 조회", description = "특정 책에 달린 유명인들의 인용 목록을 조회합니다. (맥락 점수 높은 순)")
     @ApiResponses(value = {


### PR DESCRIPTION
## 📝 작업 요약
Spring Boot 4(Hibernate Validator 9) 업그레이드로 인해 `@Validated` 컨트롤러의 모든 엔드포인트에서 500이 발생하던 문제 수정

## 🔗 관련 이슈(있으면)
- #151

## 🛠 주요 변경 사항
- [x] `BookControllerDocs.registerBook()` 파라미터에 `@Valid` 추가
- [x] `QuoteControllerDocs.registerQuote()` 파라미터에 `@Valid` 추가

## 🔍 리뷰 포인트
- **검증**: Hibernate Validator 9에서 Bean Validation 계층 규칙이 강화됨 — 인터페이스(Docs)에 없는 `@Valid`를 구현체(Controller)가 추가하면 `HV000151: ConstraintDeclarationException` 발생
- `@Validated`가 붙은 클래스는 어떤 메서드를 호출하든 **클래스 전체** 메타데이터를 빌드하므로, `GET /api/books` 같은 무관한 엔드포인트도 `POST /api/books`의 `@Valid` 불일치로 인해 500이 되었음

## 📸 테스트 결과 (선택 사항)
- `GET /api/books` 빈 파라미터 호출 시 500 → 200 정상 응답 확인 필요

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가?
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting
### 1. 문제 현상
- `GET /api/books` 호출 시 500 Internal Server Error

### 2. 원인 분석
```
ConstraintDeclarationException: HV000151:
BookController#registerBook(BookRequest) redefines the configuration of
BookControllerDocs#registerBook(BookRequest)
```
Hibernate Validator 9이 `@Validated` 클래스의 메서드 호출 시 클래스 전체 제약 메타데이터를 검증하며, `BookControllerDocs`에 `@Valid`가 없는데 `BookController`에 있어 위반 발생

### 3. 해결 방안
인터페이스(Docs)와 구현체(Controller)의 파라미터 제약 조건을 일치시킴 → `@Valid` 추가