### PR TITLE
fix: plain.jar 중복 생성 해제 및 배포 헬스체크 쉘 폭사 방지 핫픽스

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,7 @@ jobs:
             echo "=== Step 5: Health Check ==="
             sleep 30
 
-            HEALTH=$(docker exec "${CONTAINER_PREFIX}-$NEW" curl -s http://localhost:8080/api/health)
+            HEALTH=$(docker exec "${CONTAINER_PREFIX}-$NEW" curl -s http://localhost:8080/api/health || echo "FAILED")
 
             if echo "$HEALTH" | grep -q '"status"\s*:\s*"UP"'; then
               echo "Health check passed!"

--- a/build.gradle
+++ b/build.gradle
@@ -66,3 +66,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+jar {
+    enabled = false
+}


### PR DESCRIPTION
### 🛠️ 2차 추가 핫픽스 반영 완료 (Clean PR)
최신 develop 브랜치에 앞선 1차 핫픽스가 머지된 것을 확인하고, 2차 배포 실패(헬스체크 실패)의 두 핵심 원인을 격파하기 위한 새로운 Clean PR을 최종 개설했습니다.

1. **plain.jar 중복 생성 차단 (`build.gradle` 수정)**
   * Gradle 빌드 시 실행 권한이 없는 plain.jar가 동시에 복사되어 JVM 기동 오류(Main Manifest Attribute 누락)를 유발하던 문제를 `jar { enabled = false }` 설정으로 원천 봉쇄했습니다. 
   * 이로써 오직 실행 가능한 단일 fat-jar만 안전히 복사되어 컨테이너가 정상 구동됩니다.
2. **헬스체크 쉘 즉시 폭사 방지 (`deploy.yml` 수정)**
   * `set -e` 상태에서 curl 실패 시 쉘이 롤백과 에러 로그 수집을 채 해보기도 전에 조기 종료되던 스크립트 버그를 `|| echo "FAILED"` 래퍼로 완벽 보완했습니다. 
   * 이제 에러 발생 시 안정적으로 이전 컨테이너 상태로 롤백하고 Actions 화면에 컨테이너 로그를 온전히 뿌려줍니다.