### PR TITLE
fix: Nginx 프록시 및 배포 헬스체크 포트를 Spring Boot 포트 8081로 일치 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -214,7 +214,7 @@ jobs:
             echo "=== Step 5: Health Check ==="
             sleep 30
 
-            HEALTH=$(docker exec "${CONTAINER_PREFIX}-$NEW" curl -s http://localhost:8080/api/health || echo "FAILED")
+            HEALTH=$(docker exec "${CONTAINER_PREFIX}-$NEW" curl -s http://localhost:8081/api/health || echo "FAILED")
 
             if echo "$HEALTH" | grep -q '"status"\s*:\s*"UP"'; then
               echo "Health check passed!"

--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -45,7 +45,7 @@ server {
     location / {
         resolver 127.0.0.11 valid=30s;
         include /etc/nginx/conf.d/service-prod.inc;
-        proxy_pass http://$prod_upstream:8080;
+        proxy_pass http://$prod_upstream:8081;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -70,7 +70,7 @@ server {
     location / {
         resolver 127.0.0.11 valid=30s;
         include /etc/nginx/conf.d/service-staging.inc;
-        proxy_pass http://$staging_upstream:8080;
+        proxy_pass http://$staging_upstream:8081;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
### 🛠️ 3차 최종 핫픽스 반영 완료 (Clean PR)
1, 2차 핫픽스 머지 및 배포 가동 후, 저희가 심어둔 헬스체크 디버그 로그 확보 기능 덕분에 최종적인 근본 원인을 완벽하게 포착하고 3차 긴급 추가 PR을 개설했습니다.

* **발견된 문제**: Spring Boot 애플리케이션의 기본 기동 포트가 **`8081`** (`application.yml`에 선언)인 반면, Nginx 설정 및 배포 헬스체크 타겟 포트가 **`8080`** 으로 하드코딩되어 있었습니다. 이 불일치 때문에 Nginx가 계속 502 Bad Gateway를 던졌고 헬스체크가 실패했습니다.
* **해결 내용**:
  1. `nginx/default.conf.template` 내의 Production / Staging 가상 호스트 proxy 포트를 **`8081`**로 일치화
  2. `deploy.yml`의 헬스체크 curl 명령 타겟 포트를 **`8081`**로 일치화

이 3차 추가 핫픽스가 머지되면 Nginx가 마운트될 때 실제 애플리케이션 구동 포트로 정상 트래픽을 프록싱하게 되어 배포가 매끄럽게 통과됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 배포 시스템의 헬스 체크 포트 설정을 업데이트했습니다.
  * 애플리케이션 서버 라우팅 포트 설정을 변경했습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhoReads-umc-9th/whoreads-backend/pull/171?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->