### PR TITLE
[refactor] 알림 발송 순서 변경

### DIFF
--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryService.java
@@ -7,6 +7,6 @@ public interface NotificationHistoryService {
    NotificationResDTO.TotalInboxDTO getNotificationHistory(Long memberId, Long cursor, int size);
    NotificationResDTO.HistoryDTO readNotification(Long memberId, Long notificationId);
    Void readAllNotifications(Long memberId);
-   void saveHistory(Long memberId, FcmMessageDTO dto);
+   Long saveHistory(Long memberId, FcmMessageDTO dto);
    void deleteNotification(Long memberId,Long notificationId);
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationHistoryServiceImpl.java
@@ -68,7 +68,7 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
     }
 
     @Transactional
-    public void saveHistory(Long memberId, FcmMessageDTO dto) {
+    public Long saveHistory(Long memberId, FcmMessageDTO dto) {
         NotificationHistory history = NotificationHistory.builder()
                 .member(memberRepository.getReferenceById(memberId))
                 .title(dto.getTitle())
@@ -77,5 +77,6 @@ public class NotificationHistoryServiceImpl implements NotificationHistoryServic
                 .link(FollowLink.builder().celebrityId(dto.getCelebrityId()).bookId(dto.getBookId()).build())
                 .build();
         notificationHistoryRepository.save(history);
+        return history.getId();
     }
 }

--- a/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
+++ b/src/main/java/whoreads/backend/domain/notification/service/NotificationPushServiceImpl.java
@@ -12,8 +12,10 @@ import whoreads.backend.domain.notification.dto.MemberTokenDTO;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
-
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -29,16 +31,16 @@ public class NotificationPushServiceImpl implements NotificationPushService {
     @Transactional
     // 테스트용 알림 1개 발송 메서드
     public void sendNotification(String fcmToken, FcmMessageDTO dto) {
-        send(createMessage(fcmToken,dto),fcmToken);
+        send(createMessage(fcmToken, dto), fcmToken);
     }
 
-    private void send(Message message,String fcmToken) {
+    private void send(Message message, String fcmToken) {
         try {
             firebaseMessaging.send(message);
         } catch (FirebaseMessagingException e) {
-            MessagingErrorCode errorCode =  e.getMessagingErrorCode();
+            MessagingErrorCode errorCode = e.getMessagingErrorCode();
 
-            //유효하지 않은 토큰인 경우 즉시 삭제
+            // 유효하지 않은 토큰인 경우 즉시 삭제
             if (errorCode == MessagingErrorCode.UNREGISTERED ||
                 errorCode == MessagingErrorCode.INVALID_ARGUMENT) {
                 memberRepository.clearToken(fcmToken);
@@ -81,50 +83,77 @@ public class NotificationPushServiceImpl implements NotificationPushService {
         for (int i = 0; i < memberTokens.size(); i += FCM_BATCH_SIZE) {
             List<MemberTokenDTO> subList = memberTokens.subList(i, Math.min(i + FCM_BATCH_SIZE, memberTokens.size()));
 
-            MulticastMessage.Builder builder = MulticastMessage.builder()
-                    .addAllTokens(subList.stream()
-                            .map(MemberTokenDTO::getFcmToken)
-                            .toList())
-                    .setNotification(Notification.builder()
-                            .setTitle(dto.getTitle())
-                            .setBody(dto.getBody())
-                            .build())
-                    .setAndroidConfig(AndroidConfig.builder()
-                            .setPriority(AndroidConfig.Priority.HIGH)
-                            .setNotification(AndroidNotification.builder()
-                                    .setChannelId("high_importance_channel")
-                                    .setIcon("app_logo") // 💡 파일명 매칭
-                                    .setClickAction("FLUTTER_NOTIFICATION_CLICK")
-                                    .build())
-                            .build())
-                    .putData("title", dto.getTitle())
-                    .putData("body", dto.getBody())
-                    .putData("type", dto.getType());
-            if (dto.getCelebrityId()!=null && dto.getBookId()!=null)
-            {
-                builder
-                        .putData("celebrity_id", String.valueOf(dto.getCelebrityId()))
-                        .putData("book_id", String.valueOf(dto.getBookId()));
-            }
-            MulticastMessage message = builder.build();
-            try {
-                BatchResponse response = firebaseMessaging.sendEachForMulticast(message);
-                for (int j = 0; j< response.getResponses().size();j++)
-                {
-                    SendResponse sendResponse = response.getResponses().get(j);
-                    MemberTokenDTO tokenDTO = subList.get(j);
-                    if (sendResponse.isSuccessful()) {
-                        try {
-                            notificationHistoryService.saveHistory(tokenDTO.getMemberId(),dto);
-                        } catch (Exception e) {
-                            log.warn("[History] memberId={} 히스토리 저장 실패",tokenDTO.getMemberId());
-                        }
-                    }
+            // 1. 발송할 대상들의 히스토리를 DB에 먼저 생성
+            List<Long> historyIds = new ArrayList<>();
+            List<MemberTokenDTO> validTargets = new ArrayList<>();
+
+            for (MemberTokenDTO tokenDTO : subList) {
+                try {
+                    // DB에 먼저 저장 후 생성된 고유 ID(PK)를 반환받음
+                    Long historyId = notificationHistoryService.saveHistory(tokenDTO.getMemberId(), dto);
+                    historyIds.add(historyId);
+                    validTargets.add(tokenDTO); // 저장이 성공한 타겟만 발송 리스트에 포함
+                } catch (Exception e) {
+                    log.warn("[History] memberId={} 히스토리 저장 실패로 인해 발송 대상에서 제외", tokenDTO.getMemberId(), e);
                 }
+            }
+
+            if (validTargets.isEmpty()) continue;
+
+            // 2. 모든 유저에게 공통으로 들어갈 데이터 Map 구성
+            Map<String, String> commonData = new HashMap<>();
+            commonData.put("title", dto.getTitle());
+            commonData.put("body", dto.getBody());
+            commonData.put("type", dto.getType());
+
+            if (dto.getCelebrityId() != null && dto.getBookId() != null) {
+                commonData.put("celebrity_id", String.valueOf(dto.getCelebrityId()));
+                commonData.put("book_id", String.valueOf(dto.getBookId()));
+            }
+
+            // 공통 알림(Notification) 객체 정의
+            Notification notification = Notification.builder()
+                .setTitle(dto.getTitle())
+                .setBody(dto.getBody())
+                .build();
+
+            // 공통 안드로이드 설정 정의
+            AndroidConfig androidConfig = AndroidConfig.builder()
+                .setPriority(AndroidConfig.Priority.HIGH)
+                .setNotification(AndroidNotification.builder()
+                    .setChannelId("high_importance_channel")
+                    .setIcon("app_logo")
+                    .setClickAction("FLUTTER_NOTIFICATION_CLICK")
+                    .build())
+                .build();
+
+            // 3. 개별 데이터(History ID)와 토큰을 매핑하여 단일 Message 리스트 생성
+            List<Message> messages = new ArrayList<>();
+            for (int j = 0; j < validTargets.size(); j++) {
+                MemberTokenDTO target = validTargets.get(j);
+                Long historyId = historyIds.get(j);
+
+                // 유저별 개별 데이터 Map 복사 후 고유 History ID 주입
+                Map<String, String> userData = new HashMap<>(commonData);
+                userData.put("id", String.valueOf(historyId));
+
+                Message singleMessage = Message.builder()
+                    .setToken(target.getFcmToken())
+                    .setNotification(notification)
+                    .setAndroidConfig(androidConfig)
+                    .putAllData(userData)
+                    .build();
+
+                messages.add(singleMessage);
+            }
+
+            try {
+                BatchResponse response = firebaseMessaging.sendEach(messages);
+                log.info("[FCM] 배치 발송 완료. 성공: {}건, 실패: {}건", response.getSuccessCount(), response.getFailureCount());
+
             } catch (FirebaseMessagingException e) {
                 log.error("[FCM Error] 원인: {}, 메시지: {}", e.getMessagingErrorCode(), e.getMessage());
             }
         }
-
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- 알림 발송 시 히스토리 저장 후 발송 처리

## 🛠 주요 변경 사항
- [x] 특정 도메인(Celebrity, Library, DNA 등)의 핵심 로직 구현
- [ ] 데이터베이스 스키마(Entity) 추가 및 변경 사항
- [ ] 외부 API 또는 인프라(S3, FCM 등) 연동 설정
- [x] 공통 코드 리팩토링 및 성능 최적화

## 🔍 리뷰 포인트
- **로직**: 비즈니스 예외 상황(Exception) 처리가 적절하게 되어 있나요?
- **성능**: DB 쿼리 실행 시 N+1 문제나 비효율적인 연산이 있지는 않나요?
- **보안**: API 권한 체크나 민감 정보 노출 위험은 없는지 봐주세요.

## 📸 테스트 결과 (선택 사항)

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

## 🛠 Troubleshooting (선택 사항)
### 1. 문제 현상
- 어떤 에러가 발생했나요? (로그 메시지 첨부 권장)
- 프론트에서 알림 수신 시 알림 id가 없어 읽음 처리를 할 수 없는 문제 발생

### 2. 원인 분석
- 왜 이런 문제가 발생했는지 파악한 내용을 적어주세요.
- 서버에서 알림을 발송할 때 발송 후 성공한 것만 DB 저장 진행하였는데 먼저 생성 후 id 함께 보내는 걸로 변경
- 동일한 메시지를 보냈던 multicast 방식에서 id 필드 추가로 인한 sendEach 방식으로 전환 ( 성능 차이 없음 )

### 3. 해결 방안
- 어떻게 문제를 해결했나요? 다른 대안은 없었나요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 알림 발송 시 개별 수신자별 히스토리 저장 프로세스 개선으로 더 정확한 추적 가능
  * 히스토리 저장 실패 시 해당 수신자 제외 처리로 발송 안정성 향상
  * 토큰 오류 처리 로직 강화로 유효하지 않은 토큰 자동 제거

<!-- end of auto-generated comment: release notes by coderabbit.ai -->