### PR TITLE
chore: 대통령 태그 삭제 및 패치 조인 문제 해결

### DIFF
--- a/src/main/java/whoreads/backend/domain/celebrity/entity/CelebrityTag.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/entity/CelebrityTag.java
@@ -30,7 +30,6 @@ public enum CelebrityTag {
     COACH("코치"),
     FILM_CRITIC("영화평론가"),
     BIOLOGIST("생물학자"),
-    PRESIDENT("대통령"),
     POLITICIAN("정치인"),
     PROFESSOR("교수");
 

--- a/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
+++ b/src/main/java/whoreads/backend/domain/topic/repository/TopicBookRepository.java
@@ -13,8 +13,8 @@ import java.util.List;
 
 public interface TopicBookRepository extends JpaRepository<TopicBook, Long> {
 
-    // 특정 주제에 연결된 책들 조회 (Book 정보도 같이 가져옴 - N+1 방지)
-    @Query("SELECT tb FROM TopicBook tb JOIN FETCH tb.book JOIN FETCH tb.topic WHERE tb.topic IN :topics")
+    // 특정 주제에 연결된 책들 조회
+    @Query("SELECT tb FROM TopicBook tb JOIN FETCH tb.book WHERE tb.topic IN :topics")
     List<TopicBook> findAllByTopicInWithFetchJoin(@Param("topics") List<Topic> topics);
     
     // TopicBook과 연관된 Topic을 조인해서 Enum(TopicTag) 이름으로 바로 필터링하고, Book만 가져옴

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -29,18 +29,20 @@ public class TopicService {
         if (topics.isEmpty()) {
             return List.of();
         }
-        // N+1 문제 해결: IN 쿼리로 한 번에 가져와서 Map으로 그룹화
-        // 바꾼 이유: Topic 객체 자체를 Key로 쓰면 1차 캐시 이탈 시 매핑이 깨지므로 고유한 ID(Long)를 Key로 사용
-        Map<Long, List<Book>> booksByTopicId = topicBookRepository
-                .findAllByTopicInWithFetchJoin(topics)
-                .stream()
+        // 변경: 안정적인 매핑을 위해 안전하게 참조 호출
+        List<TopicBook> topicBooks = topicBookRepository.findAllByTopicInWithFetchJoin(topics);
+
+        Map<Long, List<Book>> booksByTopicId = topicBooks.stream()
                 .collect(Collectors.groupingBy(
                         tb -> tb.getTopic().getId(),
                         Collectors.mapping(TopicBook::getBook, Collectors.toList())
                 ));
 
         return topics.stream()
-                .map(topic -> TopicResponse.of(topic, booksByTopicId.getOrDefault(topic.getId(), List.of())))
+                .map(topic -> TopicResponse.of(
+                        topic,
+                        booksByTopicId.getOrDefault(topic.getId(), List.of())
+                ))
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- 사용하지 않는 대통령 태그 삭제
- TopicBookRepository의 Fetch join 문제 해결

## 🛠 주요 변경 사항
- DB와 ENUM 확인 시 문제가 됐던 과학관장 > 존재 X / 대통령 > 사용 X 이므로 대통령 태그 삭제 
- TopicBookRepository에서의 패치 조인 후 TopicService에서 Groupby하는 과정에서 null값이 반환되는 오류 발생 < JPA에서의 고질적인 문제, 따라서 Topic 자체는 패치 조인에 영향받지 않도록 구성

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* 셀러브리티 태그 카테고리 항목을 정리하여 목록 구조를 개선했습니다.
* 주제 기반 도서 조회 시 데이터베이스 쿼리 성능을 최적화했습니다.
* 주제별 도서 정보를 조회하고 처리하는 서비스 로직을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->