### PR TITLE
fix : 로그아웃 시 fcm 토큰 삭제

### DIFF
--- a/src/main/java/whoreads/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/whoreads/backend/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package whoreads.backend.auth.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -101,6 +102,8 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void logout(Long memberId) {
         redisTemplate.delete("RT:" + memberId);
+        Optional<Member> member = memberRepository.findById(memberId);
+        member.ifPresent(m -> m.updateFcmToken(null));
         log.info("{}번 사용자 로그아웃 - Refresh Token 삭제", memberId);
     }
 


### PR DESCRIPTION
## 📝 작업 요약
- 로그아웃 시 fcm 토큰 무효화

## 🛠 주요 변경 사항
- [x] 로그아웃시 fcm 토큰 null 하게 설정

## ✅ 체크리스트
- [x] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 로그아웃 시 FCM 토큰이 올바르게 정리되어 푸시 알림 설정이 안전하게 제거됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->