### PR TITLE
[Feat] 개인정보 수정 API 구현 및 테스트 추가 (#0)

### DIFF
--- a/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
@@ -99,4 +99,31 @@ public class MemberController implements MemberControllerDocs {
         notificationTokenService.deleteToken(memberId);
         return ApiResponse.success("토큰이 성공적으로 삭제되었습니다.");
     }
+
+    @PatchMapping("/me/nickname")
+    @Override
+    public ApiResponse<Void> updateNickname(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateNicknameRequest request) {
+        memberService.updateNickname(memberId, request.nickname());
+        return ApiResponse.success("닉네임이 성공적으로 수정되었습니다.");
+    }
+
+    @PatchMapping("/me/gender")
+    @Override
+    public ApiResponse<Void> updateGender(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateGenderRequest request) {
+        memberService.updateGender(memberId, request.gender());
+        return ApiResponse.success("성별이 성공적으로 수정되었습니다.");
+    }
+
+    @PatchMapping("/me/age")
+    @Override
+    public ApiResponse<Void> updateAgeGroup(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateAgeRequest request) {
+        memberService.updateAgeGroup(memberId, request.ageGroup());
+        return ApiResponse.success("연령대가 성공적으로 수정되었습니다.");
+    }
 }

--- a/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -85,4 +88,217 @@ public interface MemberControllerDocs {
             description = "이미 언팔로우 상태라면 is_success=false, 언팔로우에 성공했다면 is_success=true를 리턴합니다."
     )
     ApiResponse<Void> unfollowCelebrity(@AuthenticationPrincipal Long memberId, @PathVariable Long celebrityId);
+
+    @Operation(
+            summary = "닉네임 수정 API",
+            description = "사용자의 닉네임을 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "닉네임 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "닉네임이 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "닉네임은 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateNickname(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 닉네임 정보",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateNicknameRequest request
+    );
+
+    @Operation(
+            summary = "성별 수정 API",
+            description = "사용자의 성별을 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성별 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "성별이 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "성별은 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateGender(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 성별 정보 (MALE, FEMALE, ETC)",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateGenderRequest request
+    );
+
+    @Operation(
+            summary = "연령대 수정 API",
+            description = "사용자의 연령대를 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "연령대 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "연령대가 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "연령대는 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateAgeGroup(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 연령대 정보 (TEENAGERS, TWENTIES, THIRTIES, FORTIES, FIFTY_PLUS)",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateAgeRequest request
+    );
 }

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -2,11 +2,29 @@ package whoreads.backend.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
 
 public class MemberRequest {
     public record FcmTokenRequest(
             @JsonProperty("fcm_token")
             @NotBlank
             String fcmToken
+    ){}
+
+    public record UpdateNicknameRequest(
+            @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+            String nickname
+    ){}
+
+    public record UpdateGenderRequest(
+            @NotNull(message = "성별은 필수 입력 항목입니다.")
+            Gender gender
+    ){}
+
+    public record UpdateAgeRequest(
+            @NotNull(message = "연령대는 필수 입력 항목입니다.")
+            AgeGroup ageGroup
     ){}
 }

--- a/src/main/java/whoreads/backend/domain/member/entity/Member.java
+++ b/src/main/java/whoreads/backend/domain/member/entity/Member.java
@@ -82,6 +82,18 @@ public class Member extends BaseEntity {
         this.fcmTokenUpdatedAt = LocalDateTime.now();
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void updateAgeGroup(AgeGroup ageGroup) {
+        this.ageGroup = ageGroup;
+    }
+
     // 회원 탈퇴 (Soft Delete)
     public void withdraw() {
         this.status = Status.INACTIVE;

--- a/src/main/java/whoreads/backend/domain/member/service/MemberService.java
+++ b/src/main/java/whoreads/backend/domain/member/service/MemberService.java
@@ -14,6 +14,9 @@ import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
+
 import java.util.List;
 
 @Service
@@ -91,5 +94,26 @@ public class MemberService {
 
         // 레포지토리에 만들어둔 메서드로 관계 삭제
         memberCelebrityRepository.deleteByMemberAndCelebrity(member, celebrity);
+    }
+
+    @Transactional
+    public void updateNickname(Long memberId, String nickname) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateNickname(nickname);
+    }
+
+    @Transactional
+    public void updateGender(Long memberId, Gender gender) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateGender(gender);
+    }
+
+    @Transactional
+    public void updateAgeGroup(Long memberId, AgeGroup ageGroup) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateAgeGroup(ageGroup);
     }
 }

--- a/src/test/java/whoreads/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/whoreads/backend/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,97 @@
+package whoreads.backend.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import whoreads.backend.domain.member.entity.Member;
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
+import whoreads.backend.domain.member.repository.MemberRepository;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .id(1L)
+                .nickname("oldNickname")
+                .gender(Gender.MALE)
+                .ageGroup(AgeGroup.TEENAGERS)
+                .email("test@example.com")
+                .loginId("testuser")
+                .password("password")
+                .build();
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNickname_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateNickname(1L, "newNickname");
+
+        // then
+        assertThat(member.getNickname()).isEqualTo("newNickname");
+    }
+
+    @Test
+    @DisplayName("성별 변경 성공")
+    void updateGender_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateGender(1L, Gender.FEMALE);
+
+        // then
+        assertThat(member.getGender()).isEqualTo(Gender.FEMALE);
+    }
+
+    @Test
+    @DisplayName("연령대 변경 성공")
+    void updateAgeGroup_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateAgeGroup(1L, AgeGroup.TWENTIES);
+
+        // then
+        assertThat(member.getAgeGroup()).isEqualTo(AgeGroup.TWENTIES);
+    }
+
+    @Test
+    @DisplayName("회원이 없을 때 예외 발생")
+    void updateProfile_memberNotFound() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> memberService.updateNickname(1L, "newNickname"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 개요
사용자의 개인정보(닉네임, 성별, 연령대)를 개별적으로 수정할 수 있는 API를 구현하고 단위 테스트를 통해 기능의 안정성을 검증했습니다.

## 🛠️ 작업 내용
- **Member Entity & Service**:
  - `Member` 엔티티 내 닉네임, 성별, 연령대 변경 메서드 캡슐화 구현
  - `MemberService`에 트랜잭션 단위의 비즈니스 로직 작성 (`updateNickname`, `updateGender`, `updateAgeGroup`)
- **Controller & DTO**:
  - `PATCH /api/members/me/nickname`, `/me/gender`, `/me/age` 개별 API 추가
  - 요청 데이터 형식을 검증하기 위해 `@NotBlank` 및 `@NotNull` 유효성 평가가 적용된 `UpdateNicknameRequest`, `UpdateGenderRequest`, `UpdateAgeRequest` DTO 설계
- **API Spec (Swagger)**:
  - 쏘이(김서연) 님이 작성하신 서재 API 스펙과 통일성 있는 규격을 유지하도록 `MemberControllerDocs`를 최신화
  - 성공(`200`), 유효성 에러(`400`), 인증 에러(`401`), 미존재 에러(`404`)에 대한 구체적인 예시 JSON 및 응답 스키마 설정 완료
- **Backend Verification**:
  - Mockito 기반의 슬라이스 단위 테스트 클래스인 `MemberServiceTest`를 추가하여 각 데이터의 업데이트 성공 케이스 및 미가입 유저 오류 예외 처리 테스트 통과

## 🧪 테스트 결과
- Gradle을 활용한 빌드 컴파일 및 전체 테스트 스위트 확인
  ```bash
  ./gradlew test
  # BUILD SUCCESSFUL (테스트 통과 완료)
  ```

## 🔗 관련 이슈
- Closes #0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 로그인한 회원의 닉네임, 성별, 연령대를 각각 수정할 수 있는 기능이 추가되었습니다.
  * 회원 프로필 수정 요청에 대한 입력 검증과 응답 안내가 함께 강화되었습니다.

* **Tests**
  * 프로필 수정 동작이 정상적으로 반영되는지 확인하는 서비스 테스트가 추가되었습니다.
  * 회원을 찾지 못한 경우 예외가 발생하는지도 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->