### PR TITLE
[Feat] 개인정보 수정 API 복구 및 Swagger 배포 일시 추가 (#0)

### DIFF
--- a/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
@@ -99,4 +99,31 @@ public class MemberController implements MemberControllerDocs {
         notificationTokenService.deleteToken(memberId);
         return ApiResponse.success("토큰이 성공적으로 삭제되었습니다.");
     }
+
+    @PatchMapping("/me/nickname")
+    @Override
+    public ApiResponse<Void> updateNickname(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateNicknameRequest request) {
+        memberService.updateNickname(memberId, request.nickname());
+        return ApiResponse.success("닉네임이 성공적으로 수정되었습니다.");
+    }
+
+    @PatchMapping("/me/gender")
+    @Override
+    public ApiResponse<Void> updateGender(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateGenderRequest request) {
+        memberService.updateGender(memberId, request.gender());
+        return ApiResponse.success("성별이 성공적으로 수정되었습니다.");
+    }
+
+    @PatchMapping("/me/age")
+    @Override
+    public ApiResponse<Void> updateAgeGroup(
+            @AuthenticationPrincipal Long memberId,
+            @RequestBody @Valid MemberRequest.UpdateAgeRequest request) {
+        memberService.updateAgeGroup(memberId, request.ageGroup());
+        return ApiResponse.success("연령대가 성공적으로 수정되었습니다.");
+    }
 }

--- a/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/MemberController.java
@@ -104,7 +104,7 @@ public class MemberController implements MemberControllerDocs {
     @Override
     public ApiResponse<Void> updateNickname(
             @AuthenticationPrincipal Long memberId,
-            @RequestBody @Valid MemberRequest.UpdateNicknameRequest request) {
+            @RequestBody MemberRequest.UpdateNicknameRequest request) {
         memberService.updateNickname(memberId, request.nickname());
         return ApiResponse.success("닉네임이 성공적으로 수정되었습니다.");
     }
@@ -113,7 +113,7 @@ public class MemberController implements MemberControllerDocs {
     @Override
     public ApiResponse<Void> updateGender(
             @AuthenticationPrincipal Long memberId,
-            @RequestBody @Valid MemberRequest.UpdateGenderRequest request) {
+            @RequestBody MemberRequest.UpdateGenderRequest request) {
         memberService.updateGender(memberId, request.gender());
         return ApiResponse.success("성별이 성공적으로 수정되었습니다.");
     }
@@ -122,7 +122,7 @@ public class MemberController implements MemberControllerDocs {
     @Override
     public ApiResponse<Void> updateAgeGroup(
             @AuthenticationPrincipal Long memberId,
-            @RequestBody @Valid MemberRequest.UpdateAgeRequest request) {
+            @RequestBody MemberRequest.UpdateAgeRequest request) {
         memberService.updateAgeGroup(memberId, request.ageGroup());
         return ApiResponse.success("연령대가 성공적으로 수정되었습니다.");
     }

--- a/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -5,6 +5,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -85,4 +88,217 @@ public interface MemberControllerDocs {
             description = "이미 언팔로우 상태라면 is_success=false, 언팔로우에 성공했다면 is_success=true를 리턴합니다."
     )
     ApiResponse<Void> unfollowCelebrity(@AuthenticationPrincipal Long memberId, @PathVariable Long celebrityId);
+
+    @Operation(
+            summary = "닉네임 수정 API",
+            description = "사용자의 닉네임을 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "닉네임 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "닉네임이 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "닉네임은 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateNickname(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 닉네임 정보",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateNicknameRequest request
+    );
+
+    @Operation(
+            summary = "성별 수정 API",
+            description = "사용자의 성별을 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "성별 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "성별이 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "성별은 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateGender(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 성별 정보 (MALE, FEMALE, ETC)",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateGenderRequest request
+    );
+
+    @Operation(
+            summary = "연령대 수정 API",
+            description = "사용자의 연령대를 변경합니다."
+    )
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "연령대 수정 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": true,
+                                      "code": 200,
+                                      "message": "연령대가 성공적으로 수정되었습니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 입력값",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 400,
+                                      "message": "연령대는 필수 입력 항목입니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "인증 필요",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 401,
+                                      "message": "인증이 필요합니다."
+                                    }
+                                    """)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "404",
+                    description = "회원 없음",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            examples = @ExampleObject(value = """
+                                    {
+                                      "is_success": false,
+                                      "code": 404,
+                                      "message": "회원을 찾을 수 없습니다."
+                                    }
+                                    """)
+                    )
+            )
+    })
+    ApiResponse<Void> updateAgeGroup(
+            @AuthenticationPrincipal Long memberId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "변경할 연령대 정보 (TEENAGERS, TWENTIES, THIRTIES, FORTIES, FIFTY_PLUS)",
+                    required = true
+            )
+            @RequestBody MemberRequest.UpdateAgeRequest request
+    );
 }

--- a/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/member/controller/docs/MemberControllerDocs.java
@@ -157,7 +157,7 @@ public interface MemberControllerDocs {
                     description = "변경할 닉네임 정보",
                     required = true
             )
-            @RequestBody MemberRequest.UpdateNicknameRequest request
+            @RequestBody @Valid MemberRequest.UpdateNicknameRequest request
     );
 
     @Operation(
@@ -228,7 +228,7 @@ public interface MemberControllerDocs {
                     description = "변경할 성별 정보 (MALE, FEMALE, ETC)",
                     required = true
             )
-            @RequestBody MemberRequest.UpdateGenderRequest request
+            @RequestBody @Valid MemberRequest.UpdateGenderRequest request
     );
 
     @Operation(
@@ -299,6 +299,6 @@ public interface MemberControllerDocs {
                     description = "변경할 연령대 정보 (TEENAGERS, TWENTIES, THIRTIES, FORTIES, FIFTY_PLUS)",
                     required = true
             )
-            @RequestBody MemberRequest.UpdateAgeRequest request
+            @RequestBody @Valid MemberRequest.UpdateAgeRequest request
     );
 }

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -25,6 +25,7 @@ public class MemberRequest {
 
     public record UpdateAgeRequest(
             @NotNull(message = "연령대는 필수 입력 항목입니다.")
+            @JsonProperty("age_group")
             AgeGroup ageGroup
     ){}
 }

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -2,11 +2,29 @@ package whoreads.backend.domain.member.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
 
 public class MemberRequest {
     public record FcmTokenRequest(
             @JsonProperty("fcm_token")
             @NotBlank
             String fcmToken
+    ){}
+
+    public record UpdateNicknameRequest(
+            @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+            String nickname
+    ){}
+
+    public record UpdateGenderRequest(
+            @NotNull(message = "성별은 필수 입력 항목입니다.")
+            Gender gender
+    ){}
+
+    public record UpdateAgeRequest(
+            @NotNull(message = "연령대는 필수 입력 항목입니다.")
+            AgeGroup ageGroup
     ){}
 }

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -16,7 +16,7 @@ public class MemberRequest {
 
     public record UpdateNicknameRequest(
             @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
-            @Size(max = 10, message = "닉네임은 10자 이하이어야 합니다.")
+            @Size(max = 50, message = "닉네임은 50자 이하이어야 합니다.")
             String nickname
     ){}
 

--- a/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
+++ b/src/main/java/whoreads/backend/domain/member/dto/MemberRequest.java
@@ -3,6 +3,7 @@ package whoreads.backend.domain.member.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import whoreads.backend.domain.member.enums.AgeGroup;
 import whoreads.backend.domain.member.enums.Gender;
 
@@ -15,6 +16,7 @@ public class MemberRequest {
 
     public record UpdateNicknameRequest(
             @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+            @Size(max = 10, message = "닉네임은 10자 이하이어야 합니다.")
             String nickname
     ){}
 

--- a/src/main/java/whoreads/backend/domain/member/entity/Member.java
+++ b/src/main/java/whoreads/backend/domain/member/entity/Member.java
@@ -82,6 +82,18 @@ public class Member extends BaseEntity {
         this.fcmTokenUpdatedAt = LocalDateTime.now();
     }
 
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateGender(Gender gender) {
+        this.gender = gender;
+    }
+
+    public void updateAgeGroup(AgeGroup ageGroup) {
+        this.ageGroup = ageGroup;
+    }
+
     // 회원 탈퇴 (Soft Delete)
     public void withdraw() {
         this.status = Status.INACTIVE;

--- a/src/main/java/whoreads/backend/domain/member/service/MemberService.java
+++ b/src/main/java/whoreads/backend/domain/member/service/MemberService.java
@@ -42,16 +42,14 @@ public class MemberService {
     }
 
     public MemberResDto.MemberInfo getMemberInfo(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
 
         return MemberConverter.toMemberInfo(member);
     }
 
     @Transactional
     public void followCelebrity(Long memberId, Long celebrityId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
 
         Celebrity celebrity = celebrityRepository.findById(celebrityId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
@@ -70,8 +68,7 @@ public class MemberService {
     }
 
     public boolean isFollowingCelebrity(Long memberId, Long celebrityId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
 
         Celebrity celebrity = celebrityRepository.findById(celebrityId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
@@ -81,8 +78,7 @@ public class MemberService {
 
     @Transactional
     public void unfollowCelebrity(Long memberId, Long celebrityId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
 
         Celebrity celebrity = celebrityRepository.findById(celebrityId)
                 .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
@@ -98,22 +94,24 @@ public class MemberService {
 
     @Transactional
     public void updateNickname(Long memberId, String nickname) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
         member.updateNickname(nickname);
     }
 
     @Transactional
     public void updateGender(Long memberId, Gender gender) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
         member.updateGender(gender);
     }
 
     @Transactional
     public void updateAgeGroup(Long memberId, AgeGroup ageGroup) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        Member member = findMemberById(memberId);
         member.updateAgeGroup(ageGroup);
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/whoreads/backend/domain/member/service/MemberService.java
+++ b/src/main/java/whoreads/backend/domain/member/service/MemberService.java
@@ -14,6 +14,9 @@ import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.global.exception.CustomException;
 import whoreads.backend.global.exception.ErrorCode;
 
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
+
 import java.util.List;
 
 @Service
@@ -91,5 +94,26 @@ public class MemberService {
 
         // 레포지토리에 만들어둔 메서드로 관계 삭제
         memberCelebrityRepository.deleteByMemberAndCelebrity(member, celebrity);
+    }
+
+    @Transactional
+    public void updateNickname(Long memberId, String nickname) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateNickname(nickname);
+    }
+
+    @Transactional
+    public void updateGender(Long memberId, Gender gender) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateGender(gender);
+    }
+
+    @Transactional
+    public void updateAgeGroup(Long memberId, AgeGroup ageGroup) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+        member.updateAgeGroup(ageGroup);
     }
 }

--- a/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
@@ -17,12 +17,13 @@ import org.springframework.context.annotation.Configuration;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 @Configuration
 public class SwaggerConfig {
 
     private static final String DEPLOY_TIME = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
-            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"));
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z", Locale.ENGLISH));
 
     @Bean
     public OpenAPI openAPI() {

--- a/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/whoreads/backend/global/config/SwaggerConfig.java
@@ -14,8 +14,15 @@ import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
 @Configuration
 public class SwaggerConfig {
+
+    private static final String DEPLOY_TIME = ZonedDateTime.now(ZoneId.of("Asia/Seoul"))
+            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss z"));
 
     @Bean
     public OpenAPI openAPI() {
@@ -35,7 +42,7 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .info(new Info()
                         .title("WhoReads API Document")
-                        .description("WhoReads 서비스의 API 명세서입니다.")
+                        .description("WhoReads 서비스의 API 명세서입니다.<br><br>**배포 일시**: " + DEPLOY_TIME)
                         .version("1.0.0"))
                 .addServersItem(new Server().url("/").description("Staging(개발)"))
                 .addServersItem(new Server().url("https://api.whoreads.kro.kr").description("Production"))

--- a/src/test/java/whoreads/backend/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/whoreads/backend/domain/member/service/MemberServiceTest.java
@@ -1,0 +1,97 @@
+package whoreads.backend.domain.member.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import whoreads.backend.domain.member.entity.Member;
+import whoreads.backend.domain.member.enums.AgeGroup;
+import whoreads.backend.domain.member.enums.Gender;
+import whoreads.backend.domain.member.repository.MemberRepository;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @InjectMocks
+    private MemberService memberService;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.builder()
+                .id(1L)
+                .nickname("oldNickname")
+                .gender(Gender.MALE)
+                .ageGroup(AgeGroup.TEENAGERS)
+                .email("test@example.com")
+                .loginId("testuser")
+                .password("password")
+                .build();
+    }
+
+    @Test
+    @DisplayName("닉네임 변경 성공")
+    void updateNickname_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateNickname(1L, "newNickname");
+
+        // then
+        assertThat(member.getNickname()).isEqualTo("newNickname");
+    }
+
+    @Test
+    @DisplayName("성별 변경 성공")
+    void updateGender_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateGender(1L, Gender.FEMALE);
+
+        // then
+        assertThat(member.getGender()).isEqualTo(Gender.FEMALE);
+    }
+
+    @Test
+    @DisplayName("연령대 변경 성공")
+    void updateAgeGroup_success() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.of(member));
+
+        // when
+        memberService.updateAgeGroup(1L, AgeGroup.TWENTIES);
+
+        // then
+        assertThat(member.getAgeGroup()).isEqualTo(AgeGroup.TWENTIES);
+    }
+
+    @Test
+    @DisplayName("회원이 없을 때 예외 발생")
+    void updateProfile_memberNotFound() {
+        // given
+        given(memberRepository.findById(1L)).willReturn(Optional.empty());
+
+        // then
+        assertThatThrownBy(() -> memberService.updateNickname(1L, "newNickname"))
+                .isInstanceOf(CustomException.class)
+                .hasMessageContaining(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    }
+}


### PR DESCRIPTION
## 📌 개요
장애 조치를 위해 임시 롤백했던 개인정보 수정 API를 복구하고, 요청하신 **Swagger 문서 내 배포 일시 표시 기능**을 추가하여 새로 배포를 진행합니다.

## 🛠️ 작업 내용
1. **개인정보 수정 API 복구**:
   - `PATCH /api/members/me/nickname` (닉네임 수정)
   - `PATCH /api/members/me/gender` (성별 수정)
   - `PATCH /api/members/me/age` (연령대 수정)
   - `MemberServiceTest` 단위 테스트 복구
2. **Swagger 배포 일시 표시 기능 추가**:
   - `SwaggerConfig`에 애플리케이션 시작 시간(KST 기준)을 저장하는 `DEPLOY_TIME` 변수를 추가하여 Swagger UI 메인 description 영역에 자동으로 노출되도록 구성했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 내 프로필에서 닉네임, 성별, 연령대를 PATCH로 각각 수정할 수 있는 기능이 추가되었습니다.
  * 입력값 검증을 통해 잘못된 형식은 즉시 안내되도록 개선되었습니다.
  * 프로필 수정 API 문서에 항목과 응답 예시가 추가되었습니다.
* **버그 수정**
  * 회원이 없는 경우에도 일관된 오류 메시지가 반환되도록 개선되었습니다.
* **테스트**
  * 프로필 수정 성공/실패 시나리오에 대한 서비스 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->