### PR TITLE
feat: 주제별 도서 목록 조회 API 추가

### DIFF
--- a/src/main/java/whoreads/backend/domain/topic/controller/TopicController.java
+++ b/src/main/java/whoreads/backend/domain/topic/controller/TopicController.java
@@ -1,12 +1,17 @@
 package whoreads.backend.domain.topic.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import whoreads.backend.domain.book.dto.BookResponse;
 import whoreads.backend.domain.topic.controller.docs.TopicControllerDocs;
 import whoreads.backend.domain.topic.dto.TopicResponse;
+import whoreads.backend.domain.topic.entity.TopicTag;
 import whoreads.backend.domain.topic.service.TopicService;
 
 import java.util.List;
@@ -22,5 +27,14 @@ public class TopicController implements TopicControllerDocs {
     @GetMapping
     public ResponseEntity<List<TopicResponse>> getAllTopics() {
         return ResponseEntity.ok(topicService.getAllTopics());
+    }
+
+    @Override
+    @GetMapping("/{theme}/books")
+    public ResponseEntity<List<BookResponse>> getBooksByTopic(
+            @PathVariable("theme") TopicTag theme,
+            @PageableDefault(size = 10) Pageable pageable
+    ) {
+        return ResponseEntity.ok(topicService.getBooksByTopic(theme, pageable));
     }
 }

--- a/src/main/java/whoreads/backend/domain/topic/controller/docs/TopicControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/topic/controller/docs/TopicControllerDocs.java
@@ -1,9 +1,15 @@
 package whoreads.backend.domain.topic.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import whoreads.backend.domain.book.dto.BookResponse;
 import whoreads.backend.domain.topic.dto.TopicResponse;
+import whoreads.backend.domain.topic.entity.TopicTag;
+
 import java.util.List;
 
 @Tag(name = "Topic (주제 큐레이션)", description = "주제별 추천 도서 조회 API")
@@ -11,4 +17,10 @@ public interface TopicControllerDocs {
 
     @Operation(summary = "주제별 도서 목록 조회", description = "메인 화면에 노출되는 주제별 추천 도서 목록을 조회합니다.") // 바꾼 이유: API의 목적을 명확히 함
     ResponseEntity<List<TopicResponse>> getAllTopics();
+
+    @Operation(summary = "특정 주제별 도서 목록 조회", description = "선택한 특정 주제 탭에 해당하는 도서 목록을 페이징하여 조회합니다.")
+    ResponseEntity<List<BookResponse>> getBooksByTopic(
+            @Parameter(description = "주제 태그 (예: LIFE_DIRECTION, MINDSET 등)", required = true) TopicTag theme,
+            @ParameterObject Pageable pageable
+    );
 }

--- a/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
+++ b/src/main/java/whoreads/backend/domain/topic/service/TopicService.java
@@ -1,12 +1,15 @@
 package whoreads.backend.domain.topic.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import whoreads.backend.domain.book.dto.BookResponse;
 import whoreads.backend.domain.book.entity.Book;
 import whoreads.backend.domain.topic.dto.TopicResponse;
 import whoreads.backend.domain.topic.entity.Topic;
 import whoreads.backend.domain.topic.entity.TopicBook;
+import whoreads.backend.domain.topic.entity.TopicTag;
 import whoreads.backend.domain.topic.repository.TopicBookRepository;
 import whoreads.backend.domain.topic.repository.TopicRepository;
 
@@ -43,6 +46,14 @@ public class TopicService {
                         topic,
                         booksByTopicId.getOrDefault(topic.getId(), List.of())
                 ))
+                .collect(Collectors.toList());
+    }
+
+    public List<BookResponse> getBooksByTopic(TopicTag theme, Pageable pageable) {
+        List<Book> books = topicBookRepository.findBooksByThemeName(theme, pageable);
+
+        return books.stream()
+                .map(BookResponse::from)
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- 주제별 도서 목록 조회 API 추가

## 🛠 주요 변경 사항
- 특정 주제 탭 선택 시 해당 주제의 도서 목록만 페이징 처리하여 조회하는 엔드포인트 구현 (GET /api/topics/{theme}/books).

## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 주제별로 관련 도서 목록을 조회할 수 있는 새 기능이 추가되었습니다.
  * 결과는 페이지 단위로 제공되며, 기본 표시 개수는 10권입니다.
  * API 문서에도 해당 조회 기능이 반영되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->