### PR TITLE
[Feat] 프로필 이미지 get, patch api 설계

### DIFF
--- a/src/main/java/whoreads/backend/domain/celebrity/controller/CelebrityController.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/controller/CelebrityController.java
@@ -1,11 +1,14 @@
 package whoreads.backend.domain.celebrity.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import whoreads.backend.domain.celebrity.controller.docs.CelebrityControllerDocs;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageRequest;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageResponse;
 import whoreads.backend.domain.celebrity.dto.CelebrityResponse;
 import whoreads.backend.domain.celebrity.entity.CelebrityTag;
 import whoreads.backend.domain.celebrity.service.CelebrityService;
@@ -35,5 +38,22 @@ public class CelebrityController implements CelebrityControllerDocs {
             @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id) {
         // 바꾼 이유: 음수나 0 같은 비정상적인 ID가 들어오는 것을 컨트롤러 단에서 미리 차단
         return ResponseEntity.ok(celebrityService.getCelebrity(id));
+    }
+
+    // 3. 프로필 이미지 조회
+    @Override
+    @GetMapping("/{id}/image")
+    public ResponseEntity<CelebrityImageResponse> getCelebrityImage(
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id) {
+        return ResponseEntity.ok(celebrityService.getCelebrityImage(id));
+    }
+
+    // 4. 프로필 이미지 수정 (PATCH)
+    @Override
+    @PatchMapping("/{id}/image")
+    public ResponseEntity<CelebrityImageResponse> updateCelebrityImage(
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id,
+            @RequestBody @Valid CelebrityImageRequest request) {
+        return ResponseEntity.ok(celebrityService.updateCelebrityImage(id, request));
     }
 }

--- a/src/main/java/whoreads/backend/domain/celebrity/controller/docs/CelebrityControllerDocs.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/controller/docs/CelebrityControllerDocs.java
@@ -6,10 +6,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestBody;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageRequest;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageResponse;
 import whoreads.backend.domain.celebrity.dto.CelebrityResponse;
 import whoreads.backend.domain.celebrity.entity.CelebrityTag;
 
@@ -33,5 +37,19 @@ public interface CelebrityControllerDocs {
     ResponseEntity<CelebrityResponse> getCelebrityById(
             @Parameter(description = "유명인 ID (1 이상)", required = true)
             @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id // 바꾼 이유: 파라미터 제약조건 문서화
+    );
+    // 📌 추가된 프로필 이미지 조회 명세
+    @Operation(summary = "유명인 프로필 이미지 조회", description = "특정 유명인의 프로필 이미지 URL을 조회합니다.")
+    ResponseEntity<CelebrityImageResponse> getCelebrityImage(
+            @Parameter(description = "유명인 ID", required = true)
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id
+    );
+
+    // 📌 추가된 프로필 이미지 수정 명세
+    @Operation(summary = "유명인 프로필 이미지 수정 (PATCH)", description = "특정 유명인의 프로필 이미지 URL을 수정합니다.")
+    ResponseEntity<CelebrityImageResponse> updateCelebrityImage(
+            @Parameter(description = "유명인 ID", required = true)
+            @PathVariable @Positive(message = "올바른 유명인 ID를 입력해주세요.") Long id,
+            @RequestBody @Valid CelebrityImageRequest request // 📌 깰끔하게 import 완료
     );
 }

--- a/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityImageRequest.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityImageRequest.java
@@ -1,0 +1,17 @@
+package whoreads.backend.domain.celebrity.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.URL;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CelebrityImageRequest {
+
+    @JsonProperty("image_url")
+    @NotBlank(message = "이미지 URL은 필수입니다.")
+    @URL(message = "올바른 URL 형식이어야 합니다.")
+    private String imageUrl;
+}

--- a/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityImageResponse.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/dto/CelebrityImageResponse.java
@@ -1,0 +1,17 @@
+package whoreads.backend.domain.celebrity.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CelebrityImageResponse {
+    private Long id;
+    @JsonProperty("image_url")
+    private String imageUrl;
+
+    public static CelebrityImageResponse from(Long id, String imageUrl) {
+        return new CelebrityImageResponse(id, imageUrl);
+    }
+}

--- a/src/main/java/whoreads/backend/domain/celebrity/entity/Celebrity.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/entity/Celebrity.java
@@ -45,6 +45,12 @@ public class Celebrity extends BaseEntity {
     @Builder.Default
     private List<CelebrityBook> celebrityBookList = new ArrayList<>();
 
+    public void updateImageUrl(String imageUrl) {
+        if (imageUrl != null && !imageUrl.trim().isEmpty()) {
+            this.imageUrl = imageUrl.trim();
+        }
+    }
+
     @Builder
     public Celebrity(String name, String imageUrl, String shortBio, List<CelebrityTag> jobTags) {
         this.name = name;

--- a/src/main/java/whoreads/backend/domain/celebrity/service/CelebrityService.java
+++ b/src/main/java/whoreads/backend/domain/celebrity/service/CelebrityService.java
@@ -3,6 +3,8 @@ package whoreads.backend.domain.celebrity.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageRequest;
+import whoreads.backend.domain.celebrity.dto.CelebrityImageResponse;
 import whoreads.backend.domain.celebrity.dto.CelebrityResponse;
 import whoreads.backend.domain.celebrity.entity.Celebrity;
 import whoreads.backend.domain.celebrity.entity.CelebrityTag;
@@ -42,5 +44,25 @@ public class CelebrityService {
                 .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
 
         return CelebrityResponse.from(celebrity);
+    }
+
+    // 유명인 프로필 이미지 조회
+    public CelebrityImageResponse getCelebrityImage(Long id) {
+        Celebrity celebrity = celebrityRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
+
+        return CelebrityImageResponse.from(celebrity.getId(), celebrity.getImageUrl());
+    }
+
+    // 유명인 프로필 이미지 수정 (PATCH)
+    @Transactional
+    public CelebrityImageResponse updateCelebrityImage(Long id, CelebrityImageRequest request) {
+        Celebrity celebrity = celebrityRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.CELEBRITY_NOT_FOUND));
+
+        // 변경 감지(Dirty Checking)로 업데이트 처리
+        celebrity.updateImageUrl(request.getImageUrl());
+
+        return CelebrityImageResponse.from(celebrity.getId(), celebrity.getImageUrl());
     }
 }


### PR DESCRIPTION
## 📝 작업 요약
- 유명인 프로필 이미지 조회 및 수정(PATCH) API 구현

## 🛠 주요 변경 사항
- GET /api/celebrities/{id}/image : 유명인 프로필 이미지 URL 조회
- PATCH /api/celebrities/{id}/image : 유명인 프로필 이미지 URL 수정

## ✅ 체크리스트
- [] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [x] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [x] API 수정사항이 있을 시 API 문서에 반영하였는가?