### PR TITLE
카카오 로그인을 인가코드 방식에서 앱 SDK 액세스 토큰 방식으로 변경

### DIFF
--- a/docs/ERD/WhoReads.sql
+++ b/docs/ERD/WhoReads.sql
@@ -12,6 +12,8 @@ CREATE TABLE `member` (
     `email` VARCHAR(255) NOT NULL UNIQUE,
     `login_id` VARCHAR(255) NOT NULL UNIQUE,
     `password` VARCHAR(255) NOT NULL,
+    `provider` ENUM('LOCAL', 'KAKAO') NOT NULL DEFAULT 'LOCAL',
+    `provider_id` VARCHAR(255) NULL COMMENT '소셜 로그인 제공자가 발급한 고유 ID (LOCAL 회원은 NULL)',
     `status` ENUM('INACTIVE', 'ACTIVE') NOT NULL,
     `dna_type` VARCHAR(255) NULL,
     `dna_type_name` VARCHAR(255) NULL,
@@ -20,7 +22,8 @@ CREATE TABLE `member` (
     `deleted_at` DATETIME(6) NULL,
     `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     `updated_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
-    PRIMARY KEY (`id`)
+    PRIMARY KEY (`id`),
+    UNIQUE KEY `uk_member_provider` (`provider`, `provider_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 -- =============================================

--- a/src/main/java/whoreads/backend/auth/controller/AuthController.java
+++ b/src/main/java/whoreads/backend/auth/controller/AuthController.java
@@ -71,6 +71,24 @@ public class AuthController implements AuthControllerDocs {
         return ApiResponse.success("엑세스 토큰 재발급이 완료되었습니다.", refresh);
     }
 
+
+
+    @Override
+    @PostMapping("/kakao/login/token")
+    public ApiResponse<AuthResDto.KakaoLoginData> kakaoLoginWithToken(@RequestBody @Valid AuthReqDto.KakaoTokenLoginRequest request) {
+        AuthResDto.KakaoLoginData data = authService.kakaoLoginWithToken(request);
+
+        return ApiResponse.success("카카오 로그인 처리가 완료되었습니다.", data);
+    }
+
+    @Override
+    @PostMapping("/kakao/signup")
+    public ApiResponse<AuthResDto.TokenData> kakaoSignup(@RequestBody @Valid AuthReqDto.KakaoSignUpRequest request) {
+        AuthResDto.TokenData tokenData = authService.kakaoSignup(request);
+
+        return ApiResponse.created("카카오 회원가입에 성공했습니다.", tokenData);
+    }
+
     @Override
     @PatchMapping("/delete")
     public ApiResponse<Void> delete(@AuthenticationPrincipal Long memberId) {

--- a/src/main/java/whoreads/backend/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/whoreads/backend/auth/controller/AuthControllerDocs.java
@@ -51,6 +51,29 @@ public interface AuthControllerDocs {
     ApiResponse<AuthResDto.TokenData> refresh(@RequestBody @Valid AuthReqDto.RefreshRequest request);
 
 
+    @Operation(summary = "카카오 로그인 (모바일 앱)",
+            description = "카카오 SDK(iOS/Android)가 이미 발급받은 카카오 access_token으로 로그인을 시도합니다. \n\n" +
+                    "- 이미 가입된 회원이면 `is_new_member=false`와 함께 로그인 토큰(`token_data`)을 반환합니다. \n\n" +
+                    "- 처음 로그인하는 회원이면 `is_new_member=true`와 함께 10분간 유효한 `registration_token`을 반환합니다. " +
+                    "이 토큰으로 `/api/auth/kakao/signup`을 호출해 회원가입을 완료해야 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (신규/기존 여부는 is_new_member로 구분)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이메일 제공에 동의하지 않은 카카오 계정"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "502", description = "카카오 서버와 통신 실패")
+    })
+    ApiResponse<AuthResDto.KakaoLoginData> kakaoLoginWithToken(@RequestBody @Valid AuthReqDto.KakaoTokenLoginRequest request);
+
+
+    @Operation(summary = "카카오 회원가입",
+            description = "`/api/auth/kakao/login` 응답으로 받은 `registration_token`과 닉네임/성별/연령대를 전달해 회원가입을 완료합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "회원가입 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "만료되었거나 유효하지 않은 registration_token"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "이미 가입된 카카오 계정 또는 이메일 중복")
+    })
+    ApiResponse<AuthResDto.TokenData> kakaoSignup(@RequestBody @Valid AuthReqDto.KakaoSignUpRequest request);
+
+
     @Operation(
             summary = "회원 탈퇴",
             description = "현재 로그인한 사용자의 계정을 즉시 탈퇴하지 않습니다. 비활성화 상태로 변경하고 7일이 지나면 토큰을 삭제하고 계정을 탈퇴합니다."

--- a/src/main/java/whoreads/backend/auth/dto/AuthReqDto.java
+++ b/src/main/java/whoreads/backend/auth/dto/AuthReqDto.java
@@ -71,6 +71,33 @@ public class AuthReqDto {
         String refreshToken
     ){}
 
+    // 카카오 로그인 (모바일 앱: 카카오 SDK가 이미 발급받은 access_token을 그대로 전달)
+    public record KakaoTokenLoginRequest(
+            @JsonProperty("access_token")
+            @Schema(description = "카카오 SDK로 발급받은 카카오 access_token", example = "abcd1234...")
+            @NotBlank
+            String accessToken
+    ){}
+
+    // 카카오 최초 로그인 시 추가 정보를 입력받아 회원가입을 완료
+    public record KakaoSignUpRequest(
+            @JsonProperty("registration_token")
+            @Schema(description = "카카오 로그인 응답으로 받은 임시 가입용 토큰", example = "eyJhbGciOiJIUzI1NiJ...")
+            @NotBlank
+            String registrationToken,
+
+            @Schema(description = "닉네임", example = "woody123")
+            @NotBlank
+            String nickname,
+
+            @NotNull
+            Gender gender,
+
+            @JsonProperty("age_group")
+            @NotNull
+            AgeGroup ageGroup
+    ){}
+
     public record MemberInfo(
             @NotBlank
             String nickname,

--- a/src/main/java/whoreads/backend/auth/dto/AuthResDto.java
+++ b/src/main/java/whoreads/backend/auth/dto/AuthResDto.java
@@ -29,4 +29,18 @@ public class AuthResDto {
             @JsonProperty("refresh_token") String refreshToken,
             @JsonProperty("access_token_expires_in") Long accessTokenExpiresIn
     ){}
+
+    @Builder
+    public record KakaoLoginData(
+            // true: 신규 회원 -> registrationToken으로 /kakao/signup 호출 필요
+            // false: 기존 회원 -> tokenData로 바로 로그인 완료
+            @JsonProperty("is_new_member")
+            boolean isNewMember,
+            @JsonProperty("token_data")
+            TokenData tokenData,
+            @JsonProperty("registration_token")
+            String registrationToken,
+            String email,
+            String nickname
+    ){}
 }

--- a/src/main/java/whoreads/backend/auth/dto/KakaoUserInfoDto.java
+++ b/src/main/java/whoreads/backend/auth/dto/KakaoUserInfoDto.java
@@ -1,0 +1,21 @@
+package whoreads.backend.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfoDto(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record KakaoAccount(
+            String email,
+            Profile profile
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record Profile(
+            String nickname
+    ) {}
+}

--- a/src/main/java/whoreads/backend/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/whoreads/backend/auth/jwt/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package whoreads.backend.auth.jwt;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
@@ -12,6 +13,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 import whoreads.backend.auth.dto.AuthResDto;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
 
 import java.security.Key;
 import java.util.Collections;
@@ -39,6 +42,10 @@ import java.util.Date;
 @Slf4j
 @Component
 public class JwtTokenProvider {
+
+    // 카카오 회원가입용 임시 토큰(신규 회원이 추가 정보를 입력하는 동안만 유효) - 10분
+    private static final long KAKAO_REGISTRATION_TOKEN_VALIDITY = 1000L * 60 * 10;
+    private static final String KAKAO_REGISTRATION_SUBJECT = "KAKAO_SIGNUP";
 
     private final Key key;
     private final long accessTokenValidityTime;
@@ -94,6 +101,35 @@ public class JwtTokenProvider {
                 .parseClaimsJws(token)
                 .getBody();
         return Long.parseLong(claims.getSubject());
+    }
+
+    // 카카오 신규 회원의 providerId/email/nickname을 담은 임시 가입용 토큰 발급
+    public String createKakaoRegistrationToken(String providerId, String email, String nickname) {
+        long now = new Date().getTime();
+
+        return Jwts.builder()
+                .setSubject(KAKAO_REGISTRATION_SUBJECT)
+                .claim("providerId", providerId)
+                .claim("email", email)
+                .claim("nickname", nickname)
+                .setIssuedAt(new Date(now))
+                .setExpiration(new Date(now + KAKAO_REGISTRATION_TOKEN_VALIDITY))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // 카카오 가입용 토큰 검증 및 클레임 추출 (일반 액세스/리프레시 토큰과 용도가 다름을 subject로 구분)
+    public Claims parseKakaoRegistrationToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            if (!KAKAO_REGISTRATION_SUBJECT.equals(claims.getSubject())) {
+                throw new CustomException(ErrorCode.INVALID_TOKEN);
+            }
+            return claims;
+        } catch (JwtException e) {
+            log.info("카카오 가입 토큰 검증 실패: {}", e.getMessage());
+            throw new CustomException(ErrorCode.INVALID_TOKEN);
+        }
     }
 
     public AuthResDto.TokenData generateTokenResponse(Long memberId) {

--- a/src/main/java/whoreads/backend/auth/service/AuthService.java
+++ b/src/main/java/whoreads/backend/auth/service/AuthService.java
@@ -34,6 +34,10 @@ public interface AuthService {
 
     AuthResDto.TokenData refresh(AuthReqDto.RefreshRequest dto);
 
+    AuthResDto.KakaoLoginData kakaoLoginWithToken(AuthReqDto.KakaoTokenLoginRequest request);
+
+    AuthResDto.TokenData kakaoSignup(AuthReqDto.KakaoSignUpRequest request);
+
     void delete(Long memberId);
 
     void changePassword(Long memberId, AuthReqDto.PasswordChangeRequest request);

--- a/src/main/java/whoreads/backend/auth/service/AuthServiceImpl.java
+++ b/src/main/java/whoreads/backend/auth/service/AuthServiceImpl.java
@@ -1,5 +1,6 @@
 package whoreads.backend.auth.service;
 
+import io.jsonwebtoken.Claims;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,10 +13,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import whoreads.backend.auth.dto.AuthReqDto;
 import whoreads.backend.auth.dto.AuthResDto;
+import whoreads.backend.auth.dto.KakaoUserInfoDto;
 import whoreads.backend.auth.jwt.JwtTokenProvider;
 import whoreads.backend.auth.principal.CustomUserDetails;
 import whoreads.backend.domain.member.converter.MemberConverter;
 import whoreads.backend.domain.member.entity.Member;
+import whoreads.backend.domain.member.enums.Provider;
 import whoreads.backend.domain.member.enums.Status;
 import whoreads.backend.domain.member.repository.MemberRepository;
 import whoreads.backend.global.exception.CustomException;
@@ -23,6 +26,7 @@ import whoreads.backend.global.exception.ErrorCode;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Slf4j
 @Service
@@ -37,6 +41,7 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
     private final EmailService emailService;
     private final StringRedisTemplate redisTemplate;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @Override
     public AuthResDto.JoinData signup(AuthReqDto.SignUpRequest dto) {
@@ -120,6 +125,86 @@ public class AuthServiceImpl implements AuthService {
 
         // 토큰 재발급
         return jwtTokenProvider.generateTokenResponse(memberId);
+    }
+
+    @Override
+    public AuthResDto.KakaoLoginData kakaoLoginWithToken(AuthReqDto.KakaoTokenLoginRequest request) {
+        // 카카오 SDK(iOS/Android)가 이미 발급받은 access_token으로 바로 사용자 정보 조회
+        KakaoUserInfoDto userInfo = kakaoOAuthClient.requestUserInfo(request.accessToken());
+
+        return processKakaoUserInfo(userInfo);
+    }
+
+    private AuthResDto.KakaoLoginData processKakaoUserInfo(KakaoUserInfoDto userInfo) {
+        String providerId = String.valueOf(userInfo.id());
+
+        // 이미 가입된 카카오 회원이면 바로 로그인 처리
+        Member member = memberRepository.findByProviderAndProviderId(Provider.KAKAO, providerId).orElse(null);
+        if (member != null) {
+            AuthResDto.TokenData tokenData = jwtTokenProvider.generateTokenResponse(member.getId());
+            redisTemplate.opsForValue().set(
+                    "RT:" + member.getId(),
+                    tokenData.refreshToken(),
+                    Duration.ofDays(7)
+            );
+
+            return AuthResDto.KakaoLoginData.builder()
+                    .isNewMember(false)
+                    .tokenData(tokenData)
+                    .build();
+        }
+
+        // 신규 회원이면 닉네임/성별/연령대를 입력받기 위해 임시 가입용 토큰만 발급
+        String email = userInfo.kakaoAccount() != null ? userInfo.kakaoAccount().email() : null;
+        if (email == null)
+            throw new CustomException(ErrorCode.KAKAO_EMAIL_REQUIRED);
+
+        String nickname = (userInfo.kakaoAccount() != null && userInfo.kakaoAccount().profile() != null)
+                ? userInfo.kakaoAccount().profile().nickname()
+                : null;
+
+        String registrationToken = jwtTokenProvider.createKakaoRegistrationToken(providerId, email, nickname);
+
+        return AuthResDto.KakaoLoginData.builder()
+                .isNewMember(true)
+                .registrationToken(registrationToken)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
+
+    @Override
+    public AuthResDto.TokenData kakaoSignup(AuthReqDto.KakaoSignUpRequest request) {
+        Claims claims = jwtTokenProvider.parseKakaoRegistrationToken(request.registrationToken());
+        String providerId = claims.get("providerId", String.class);
+        String email = claims.get("email", String.class);
+
+        if (memberRepository.existsByProviderAndProviderId(Provider.KAKAO, providerId))
+            throw new CustomException(ErrorCode.ALREADY_REGISTERED_KAKAO);
+        validateDuplicateEmail(email);
+
+        Member member = Member.builder()
+                .provider(Provider.KAKAO)
+                .providerId(providerId)
+                .loginId("kakao_" + providerId)
+                .email(email)
+                .nickname(request.nickname())
+                .gender(request.gender())
+                .ageGroup(request.ageGroup())
+                // 소셜 로그인 회원은 비밀번호 로그인을 쓰지 않으므로, 알 수 없는 랜덤 값으로 채워 NOT NULL 제약만 만족시킨다.
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .build();
+
+        memberRepository.save(member);
+
+        AuthResDto.TokenData tokenData = jwtTokenProvider.generateTokenResponse(member.getId());
+        redisTemplate.opsForValue().set(
+                "RT:" + member.getId(),
+                tokenData.refreshToken(),
+                Duration.ofDays(7)
+        );
+
+        return tokenData;
     }
 
     @Override

--- a/src/main/java/whoreads/backend/auth/service/KakaoOAuthClient.java
+++ b/src/main/java/whoreads/backend/auth/service/KakaoOAuthClient.java
@@ -1,0 +1,59 @@
+package whoreads.backend.auth.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import whoreads.backend.auth.dto.KakaoUserInfoDto;
+import whoreads.backend.global.exception.CustomException;
+import whoreads.backend.global.exception.ErrorCode;
+
+/**
+ * 카카오 API 서버(kapi)와 통신하는 클라이언트
+ *
+ * 앱(iOS/Android)의 카카오 SDK가 이미 발급받은 access_token을 그대로 전달받아
+ * kapi.kakao.com/v2/user/me로 사용자 정보(id, email, nickname)를 조회한다.
+ */
+@Slf4j
+@Component
+public class KakaoOAuthClient {
+
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    private final RestTemplate restTemplate = createRestTemplate();
+
+    private RestTemplate createRestTemplate() {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(3000);
+        factory.setReadTimeout(3000);
+        return new RestTemplate(factory);
+    }
+
+    public KakaoUserInfoDto requestUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<Void> httpRequest = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfoDto> response = restTemplate.exchange(
+                    USER_INFO_URL, HttpMethod.GET, httpRequest, KakaoUserInfoDto.class);
+
+            KakaoUserInfoDto userInfo = response.getBody();
+            if (userInfo == null) {
+                throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+            }
+            return userInfo;
+        } catch (RestClientException e) {
+            log.error("카카오 사용자 정보 조회 중 통신 오류", e);
+            throw new CustomException(ErrorCode.KAKAO_API_ERROR);
+        }
+    }
+}

--- a/src/main/java/whoreads/backend/domain/member/entity/Member.java
+++ b/src/main/java/whoreads/backend/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import lombok.*;
 import whoreads.backend.domain.focusmode.entity.FocusTimerSetting;
 import whoreads.backend.domain.member.enums.AgeGroup;
 import whoreads.backend.domain.member.enums.Gender;
+import whoreads.backend.domain.member.enums.Provider;
 import whoreads.backend.domain.member.enums.Status;
 import whoreads.backend.domain.readingsession.entity.ReadingSession;
 import whoreads.backend.global.entity.BaseEntity;
@@ -18,7 +19,7 @@ import java.util.List;
 @Getter @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Table
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "providerId"}))
 public class Member extends BaseEntity {
 
     @Id
@@ -44,6 +45,15 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false)
     private String password;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Provider provider = Provider.LOCAL;
+
+    // 소셜 로그인 제공자가 발급한 고유 ID (LOCAL 회원은 null)
+    @Column
+    private String providerId;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/whoreads/backend/domain/member/enums/Provider.java
+++ b/src/main/java/whoreads/backend/domain/member/enums/Provider.java
@@ -1,0 +1,6 @@
+package whoreads.backend.domain.member.enums;
+
+public enum Provider {
+    LOCAL,
+    KAKAO
+}

--- a/src/main/java/whoreads/backend/domain/member/repository/MemberRepository.java
+++ b/src/main/java/whoreads/backend/domain/member/repository/MemberRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import whoreads.backend.domain.member.entity.Member;
+import whoreads.backend.domain.member.enums.Provider;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -15,6 +16,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByLoginId(String loginId);
+
+    Optional<Member> findByProviderAndProviderId(Provider provider, String providerId);
+
+    boolean existsByProviderAndProviderId(Provider provider, String providerId);
 
     @Modifying(clearAutomatically = true)
     @Query("""

--- a/src/main/java/whoreads/backend/global/exception/ErrorCode.java
+++ b/src/main/java/whoreads/backend/global/exception/ErrorCode.java
@@ -23,6 +23,10 @@ public enum ErrorCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
 
+    KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "카카오 서버와 통신 중 오류가 발생했습니다."),
+    KAKAO_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "카카오 계정의 이메일 제공에 동의해주세요."),
+    ALREADY_REGISTERED_KAKAO(HttpStatus.CONFLICT, "이미 가입된 카카오 계정입니다."),
+
     // Member
     DUPLICATE_ID(HttpStatus.CONFLICT, "이미 사용 중인 아이디입니다. 다른 아이디를 사용하세요."),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원을 찾을 수 없습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,8 +9,8 @@ spring:
   # JPA (공통 설정)
   jpa:
     hibernate:
-      ddl-auto: update
-#      ddl-auto: none
+#      ddl-auto: update
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true


### PR DESCRIPTION
## 📝 작업 요약
- 카카오 로그인을 인가코드 방식에서 앱 SDK 액세스 토큰 방식으로 변경

## 🛠 주요 변경 사항
-  iOS/Android 카카오 SDK가 발급한 access_token을 그대로 받아 사용자 정보 조회 (/kakao/login/token)                                                                               
- 토큰 교환용 client-id/client-secret/redirect-uri 설정 및 KakaoTokenResponseDto 제거                                                                                            
- 요청/응답 DTO에 snake_case JsonProperty 매핑 추가 


## ✅ 체크리스트
- [ ] 커밋 메시지 컨벤션을 준수하였는가? (Type: #이슈번호 요약내용)
- [ ] 로컬 빌드 및 단위 테스트가 정상적으로 통과되었는가?
- [ ] API 수정사항이 있을 시 API 문서에 반영하였는가?

